### PR TITLE
Auto truncate current file to fix context window for chat

### DIFF
--- a/editors/rift-vscode/src/client.ts
+++ b/editors/rift-vscode/src/client.ts
@@ -74,7 +74,8 @@ interface RunChatParams {
         role: string,
         content: string
     }[],
-    textDocument: TextDocumentIdentifier
+    position: vscode.Position,
+    textDocument: TextDocumentIdentifier,
 }
 
 

--- a/editors/rift-vscode/src/extension.ts
+++ b/editors/rift-vscode/src/extension.ts
@@ -108,9 +108,10 @@ export class ChatView implements vscode.WebviewViewProvider {
             }
             // get the uri and position of the current cursor
             const doc = editor.document;
+            const position = editor.selection.active;
             const textDocument = { uri: doc.uri.toString(), version: 0 }
             if (!data.message || !data.messages) throw new Error()
-            this.hslc.run_chat({ message: data.message, messages: data.messages, textDocument }, (progress) => {
+            this.hslc.run_chat({ message: data.message, messages: data.messages, position, textDocument }, (progress) => {
                 if (!this._view) throw new Error()
                 if (progress.done) console.log('WEBVIEW DONE RECEIVEING / POSTING')
                 this._view.webview.postMessage({ type: 'progress', data: progress });

--- a/rift-engine/rift/llm/abstract.py
+++ b/rift-engine/rift/llm/abstract.py
@@ -44,7 +44,7 @@ class AbstractCodeCompletionProvider(ABC):
 class AbstractChatCompletionProvider(ABC):
     @abstractmethod
     async def run_chat(
-        self, document: str, messages: List[Message], message: str
+        self, document: str, messages: List[Message], message: str, cursor_offset: Optional[int] = None
     ) -> ChatResult:
         """
         Process the chat messages and return the completion results.
@@ -57,6 +57,8 @@ class AbstractChatCompletionProvider(ABC):
             A list of messages exchanged in the chat.
         message: str
             The latest message exchanged in the chat.
+        cursor_offset: Optional[int]
+            The offset of the cursor in the document.
 
         Returns:
         --------

--- a/rift-engine/rift/llm/gpt4all_model.py
+++ b/rift-engine/rift/llm/gpt4all_model.py
@@ -77,6 +77,7 @@ default_args = dict(
     context_erase=0.5,
 )
 
+
 def generate_stream(self: LLModel, prompt: str, **kwargs) -> TextStream:
     loop = asyncio.get_event_loop()
     cancelled_flag = threading.Event()
@@ -122,6 +123,7 @@ def generate_stream(self: LLModel, prompt: str, **kwargs) -> TextStream:
 
     output._feed_task = asyncio.create_task(run_async())
     return output
+
 
 DEFAULT_MODEL_NAME = "ggml-gpt4all-j-v1.3-groovy"
 # DEFAULT_MODEL_NAME = "ggml-mpt-7b-chat"
@@ -197,7 +199,11 @@ class Gpt4AllModel(AbstractCodeCompletionProvider, AbstractChatCompletionProvide
         return InsertCodeResult(code=output, thoughts=None)
 
     async def run_chat(
-        self, document: str, messages: List[Message], message: str
+        self,
+        document: str,
+        messages: List[Message],
+        message: str,
+        cursor_offset: Optional[int] = None,
     ) -> ChatResult:
         logger.debug("run_chat called")
         model = await self._get_model()

--- a/rift-engine/rift/llm/openai_client.py
+++ b/rift-engine/rift/llm/openai_client.py
@@ -75,7 +75,7 @@ def message_length(msg: Message):
 Truncation Strategy:
 
 1) system message limited to MAX_SYSTEM_MESSAGE_SIZE tokens.
-2) non-system messages limited to the number of tokens available in addition to 1 and 2
+2) non-system messages limited to the number of tokens available in addition to 1 and 3
 3) model's responses buffer limited to MAX_LEN_SAMPLED_COMPLETION tokens
 """
 

--- a/rift-engine/rift/llm/openai_client.py
+++ b/rift-engine/rift/llm/openai_client.py
@@ -60,7 +60,7 @@ class OpenAIError(Exception):
 
 
 @cache
-def get_num_tokens(content):
+def get_num_tokens(content: str):
     return len(ENCODER.encode(content))
 
 
@@ -257,7 +257,7 @@ class OpenAIClient(
             )
 
     async def run_chat(
-        self, document: str, messages: List[Message], message: str
+        self, document: str, messages: List[Message], message: str, cursor_offset: Optional[int] = None
     ) -> ChatResult:
         chatstream = TextStream()
 

--- a/rift-engine/rift/llm/openai_client.py
+++ b/rift-engine/rift/llm/openai_client.py
@@ -47,9 +47,6 @@ from tiktoken import get_encoding
 ENCODER = get_encoding("cl100k_base")
 ENCODER_LOCK = Lock()
 
-# Maximum size of the context to truncate around the cursor
-MAX_CONTEXT_SIZE = 1000
-
 @dataclass
 class OpenAIError(Exception):
     """Error raised by calling the OpenAI API"""


### PR DESCRIPTION
TODO:
- [x] Define the constant MAX_CONTEXT_SIZE
- [x] Both messages and current file are truncated, how to mix both constraints
- [x] This is only for chat, and only on openai for now


Chat on a file with 7K lines:

![Screenshot 2023-06-29 at 13 48 41](https://github.com/morph-labs/rift/assets/7965335/18f81ddd-37b4-44ef-a368-1e3e8937a8c4)


Completion on the same file:
![Screenshot 2023-06-30 at 06 16 39](https://github.com/morph-labs/rift/assets/7965335/c0e69181-a39e-40f5-ba66-58710a572e91)

