### PR TITLE
fix #34

### DIFF
--- a/rift-engine/.env_example
+++ b/rift-engine/.env_example
@@ -1,0 +1,1 @@
+OPENAI_API_KEY=sk-xxx

--- a/rift-engine/pyproject.toml
+++ b/rift-engine/pyproject.toml
@@ -14,7 +14,8 @@ authors = [
 ]
 dependencies = [
   "aiohttp",
-  "pydantic[dotenv]",
+  "pydantic[dotenv]==1.*",
+  "python-dotenv",
   "rich",
   "fire",
   "gpt4all==0.3.4",


### PR DESCRIPTION
see #34 

pydantic's install is defaulting to v2 as of 06/30/23 - [link](https://docs.pydantic.dev/2.0/blog/pydantic-v2-final/) . we're using v1 and there are breaking changes to move to v2

also the project was not able to run without having the openai key in env