### PR TITLE
Rift Agents API

### DIFF
--- a/rift-engine/pyproject.toml
+++ b/rift-engine/pyproject.toml
@@ -23,6 +23,8 @@ dependencies = [
   "tiktoken",
   "sentencepiece",
   "transformers",
+  "diff_match_patch",
+  "art",
 ]
 dynamic = ["version"]
 

--- a/rift-engine/rift/agents/README.md
+++ b/rift-engine/rift/agents/README.md
@@ -1,0 +1,31 @@
+# Rift Agents API
+
+This directory contains the implementation of various agents that can be interacted with through a CLI and which produce code diffs that can be sent to an LSP server.
+
+## Files Overview
+
+- `cli_agent.py`: This file contains the base class `CliAgent` for all agents. It also includes the `ClientParams` dataclass which serves as the base class for special parameters for instances of `CliAgent`.
+- `smol.py`: This file contains an example implementation of a `CliAgent` subclass, `SmolAgent`.
+
+## `cli_agent.py` Methods
+
+- `CliAgent.run(self, *args, **kwargs) -> AsyncIterable[List[file_diff.FileChange]]`: This is an async generator which emits batches of file changes. It should be overridden by subclasses to provide the specific implementation.
+
+- `get_dataclass_function(cls)`: This function returns a function whose signature is set to be a list of arguments which are precisely the dataclass's attributes.
+
+- `main(agent_cls, params)`: This async function is the main entry point for running an agent. It starts the Rift server, displays the agent's splash screen, and runs the agent's `run` method.
+
+- `launcher(agent_cls: Type[CliAgent], param_cls: Type[ClientParams])`: This function is used to launch an agent. It uses the Fire library to parse command line arguments into an instance of `param_cls`, and then runs the `main` function with `agent_cls` and the parsed parameters.
+
+## Adding Your Own Agent
+
+To add your own agent, you need to create a new file in this directory and subclass `CliAgent`. You can use `smol.py` as a reference implementation. Here are the general steps:
+
+1. Define a new dataclass for your agent's parameters, subclassing `ClientParams`.
+2. Define your agent class, subclassing `CliAgent`. Set `run_params` to your parameters dataclass.
+3. Implement the `run` method. This method should be an async generator that yields batches of file changes.
+4. At the end of your file, call `launcher` with your agent class and parameters dataclass.
+
+## Caveat
+
+Please note that agents can run third-party code and do not use Rift's model abstractions. Be careful when running agents with untrusted code.

--- a/rift-engine/rift/agents/README.md
+++ b/rift-engine/rift/agents/README.md
@@ -1,6 +1,6 @@
 # Rift Agents API
 
-This directory contains the implementation of various agents that can be interacted with through a CLI and which produce code diffs that can be sent to an LSP server.
+This directory contains the implementation of various agents that can be interacted with through a CLI and which produce code diffs that can be sent to the Rift Code Engine.
 
 ## Files Overview
 
@@ -26,6 +26,16 @@ To add your own agent, you need to create a new file in this directory and subcl
 3. Implement the `run` method. This method should be an async generator that yields batches of file changes.
 4. At the end of your file, call `launcher` with your agent class and parameters dataclass.
 
-## Caveat
+## Running Your Own Agent
+Use the `launcher` method defined in `cli_agent.py`. See `smol.py` for a reference implementation at the bottom of the file. Once configured, just run this from the VSCode terminal:
 
-Please note that agents can run third-party code and do not use Rift's model abstractions. Be careful when running agents with untrusted code.
+```python
+# defined in ./my_agent.py
+python -m rift.agents.my_agent --port 7797 --debug False # other agent-specific flags here...
+```
+
+## Caveats
+
+- Please note that agents can run third-party code and do not use Rift's model abstractions, and presently not configurable through the Rift extension.
+- Be careful when running agents with untrusted code.
+- Currently each agent spins up its own Rift instance. Once support for [multiple clients](https://www.github.com/morph-labs/rift/issues/62) is added, multiple agents can interact with a single Rift server.

--- a/rift-engine/rift/agents/README.md
+++ b/rift-engine/rift/agents/README.md
@@ -1,6 +1,6 @@
 # Rift Agents API
 
-This directory contains the implementation of various agents that can be interacted with through a CLI and which produce code diffs that can be sent to the Rift Code Engine.
+This directory contains implementations of various agents that can be interacted with through a CLI and which produce code diffs that can be sent to the Rift Code Engine.
 
 ## Files Overview
 
@@ -36,6 +36,5 @@ python -m rift.agents.my_agent --port 7797 --debug False # other agent-specific 
 
 ## Caveats
 
-- Please note that agents can run third-party code and do not use Rift's model abstractions, and presently not configurable through the Rift extension.
-- Be careful when running agents with untrusted code.
+- Please note that agents can run third-party code, do not use Rift's model abstractions, and are presently not configurable through the Rift extension settings in VSCode. Be careful when running agents with untrusted code.
 - Currently each agent spins up its own Rift instance. Once support for [multiple clients](https://www.github.com/morph-labs/rift/issues/62) is added, multiple agents can interact with a single Rift server.

--- a/rift-engine/rift/agents/README.md
+++ b/rift-engine/rift/agents/README.md
@@ -4,25 +4,25 @@ This directory contains implementations of various agents that can be interacted
 
 ## Files Overview
 
-- `cli_agent.py`: This file contains the base class `CliAgent` for all agents. It also includes the `ClientParams` dataclass which serves as the base class for special parameters for instances of `CliAgent`.
-- `smol.py`: This file contains an example implementation of a `CliAgent` subclass, `SmolAgent`.
+- `cli_agent.py`: This file contains the base class `Agent` for all agents. It also includes the `ClientParams` dataclass which serves as the base class for special parameters for instances of `Agent`.
+- `smol.py`: This file contains an example implementation of a `Agent` subclass, `SmolAgent`.
 
 ## `cli_agent.py` Methods
 
-- `CliAgent.run(self, *args, **kwargs) -> AsyncIterable[List[file_diff.FileChange]]`: This is an async generator which emits batches of file changes. It should be overridden by subclasses to provide the specific implementation.
+- `Agent.run(self, *args, **kwargs) -> AsyncIterable[List[file_diff.FileChange]]`: This is an async generator which emits batches of file changes. It should be overridden by subclasses to provide the specific implementation.
 
 - `get_dataclass_function(cls)`: This function returns a function whose signature is set to be a list of arguments which are precisely the dataclass's attributes.
 
 - `main(agent_cls, params)`: This async function is the main entry point for running an agent. It starts the Rift server, displays the agent's splash screen, and runs the agent's `run` method.
 
-- `launcher(agent_cls: Type[CliAgent], param_cls: Type[ClientParams])`: This function is used to launch an agent. It uses the Fire library to parse command line arguments into an instance of `param_cls`, and then runs the `main` function with `agent_cls` and the parsed parameters.
+- `launcher(agent_cls: Type[Agent], param_cls: Type[ClientParams])`: This function is used to launch an agent. It uses the Fire library to parse command line arguments into an instance of `param_cls`, and then runs the `main` function with `agent_cls` and the parsed parameters.
 
 ## Adding Your Own Agent
 
-To add your own agent, you need to create a new file in this directory and subclass `CliAgent`. You can use `smol.py` as a reference implementation. Here are the general steps:
+To add your own agent, you need to create a new file in this directory and subclass `Agent`. You can use `smol.py` as a reference implementation. Here are the general steps:
 
 1. Define a new dataclass for your agent's parameters, subclassing `ClientParams`.
-2. Define your agent class, subclassing `CliAgent`. Set `run_params` to your parameters dataclass.
+2. Define your agent class, subclassing `Agent`. Set `run_params` to your parameters dataclass.
 3. Implement the `run` method. This method should be an async generator that yields batches of file changes.
 4. At the end of your file, call `launcher` with your agent class and parameters dataclass.
 

--- a/rift-engine/rift/agents/cli_agent.py
+++ b/rift-engine/rift/agents/cli_agent.py
@@ -125,6 +125,7 @@ async def main(agent_cls, params):
     client: core.CodeCapabilitiesServer = core.create_metaserver(port=params.port)
     logger.info(f"started Rift server on port {params.port}")
     t = asyncio.create_task(client.run_forever())
+    await t
 
     while True:
         await asyncio.sleep(1)

--- a/rift-engine/rift/agents/cli_agent.py
+++ b/rift-engine/rift/agents/cli_agent.py
@@ -123,7 +123,7 @@ async def main(agent_cls, params):
     )
     client: core.CodeCapabilitiesServer = core.create_metaserver(port=params.port)
     logger.info(f"started Rift server on port {params.port}")
-    t = asyncio.create_task(client.run_forever())
+    t = asyncio.create_task(client.listen_forever())
     await asyncio.sleep(1)
     if agent_cls.splash is not None:
         stream_string(agent_cls.splash)

--- a/rift-engine/rift/agents/cli_agent.py
+++ b/rift-engine/rift/agents/cli_agent.py
@@ -146,11 +146,10 @@ async def main(agent_cls, params):
             return time.time() - self._start
 
         def report_stats(self):
-            self.stats
             console.print(
                 Panel(
                     "[AgentRunStats] report:\n" + json.dumps(
-                        stats, indent=2
+                        self.stats, indent=2
                     )
                 )
             )

--- a/rift-engine/rift/agents/cli_agent.py
+++ b/rift-engine/rift/agents/cli_agent.py
@@ -123,7 +123,7 @@ async def main(agent_cls, params):
     )
     client: core.CodeCapabilitiesServer = core.create_metaserver(port=params.port)
     logger.info(f"started Rift server on port {params.port}")
-    t = asyncio.create_task(client.listen_forever())
+    t = asyncio.create_task(client.run_forever())
     await asyncio.sleep(1)
     if agent_cls.splash is not None:
         stream_string(agent_cls.splash)

--- a/rift-engine/rift/agents/cli_agent.py
+++ b/rift-engine/rift/agents/cli_agent.py
@@ -125,7 +125,6 @@ async def main(agent_cls, params):
     client: core.CodeCapabilitiesServer = core.create_metaserver(port=params.port)
     logger.info(f"started Rift server on port {params.port}")
     t = asyncio.create_task(client.run_forever())
-    await t
 
     while True:
         await asyncio.sleep(1)
@@ -176,7 +175,6 @@ async def main(agent_cls, params):
         
         await ainput("\n> Press any key to restart.\n")
         
-
     await t
 
 

--- a/rift-engine/rift/agents/cli_agent.py
+++ b/rift-engine/rift/agents/cli_agent.py
@@ -157,7 +157,7 @@ async def main(agent_cls, params):
 
     async for file_changes in agent.run():
         for file_change in file_changes:
-            agent_stats.stats["changed_files"].append(file_change.uri)
+            agent_stats.stats["changed_files"].append(file_change.uri.uri)
         await client.server.apply_workspace_edit(
             lsp.ApplyWorkspaceEditParams(
                 file_diff.edits_from_file_changes(file_changes, user_confirmation=True),

--- a/rift-engine/rift/agents/cli_agent.py
+++ b/rift-engine/rift/agents/cli_agent.py
@@ -40,6 +40,10 @@ class ClientParams:
     """
     Base class for special parameters for instances of `CliAgent`.
     Subclass to add agent-specific attributes.
+
+    Attributes:
+    port: int - The port number where the server will be running. Default is 7797.
+    debug: bool - A flag to indicate whether the application is in debug mode. Default is False.
     """
 
     port: int = 7797
@@ -56,6 +60,12 @@ class CliAgent:
     - create another file in this directory
     - subclass `CliAgent`
     - run it as a Python script with `launcher` as the entrypoint from inside a VSCode terminal (if using the Rift VSCode extension). see `smol.py` for an example.
+
+    Attributes:
+    name: str - The name of the agent.
+    run_params: ClientParams - The parameters for running the agent.
+    splash: Optional[str] - The splash screen for the agent. Default is None.
+    console: Console - The console for displaying output. Default is a new Console instance.
     """
 
     name: str
@@ -66,6 +76,8 @@ class CliAgent:
     async def run(self, *args, **kwargs) -> AsyncIterable[List[file_diff.FileChange]]:
         """
         Async generator which emits batches of file changes.
+
+        This method should be overridden by subclasses to provide the specific implementation.
         """
         ...
 

--- a/rift-engine/rift/agents/cli_agent.py
+++ b/rift-engine/rift/agents/cli_agent.py
@@ -157,7 +157,7 @@ async def main(agent_cls, params):
 
     async for file_changes in agent.run():
         for file_change in file_changes:
-            agent_stats.stats["uris"].append(file_change.uri)
+            agent_stats.stats["changed_files"].append(file_change.uri)
         await client.server.apply_workspace_edit(
             lsp.ApplyWorkspaceEditParams(
                 file_diff.edits_from_file_changes(file_changes, user_confirmation=True),

--- a/rift-engine/rift/agents/cli_agent.py
+++ b/rift-engine/rift/agents/cli_agent.py
@@ -141,12 +141,12 @@ async def main(agent_cls, params):
         def __post_init__(self):
             self.stats["elapsed_time"] = None
             self.stats["changed_files"] = list()
-        
+
         def elapsed(self):
             return time.time() - start
 
         def report_stats(self):
-            stats = self.stats
+            self.stats
             console.print(
                 Panel(
                     "[AgentRunStats] report:\n" + json.dumps(
@@ -166,7 +166,7 @@ async def main(agent_cls, params):
                 label="rift",
             )
         )
-    agent_stats.stats["elapsed_time"] = agent_stats.elapsed
+    agent_stats.stats["elapsed_time"] = agent_stats.elapsed()
 
     console.print("\n")
         

--- a/rift-engine/rift/agents/cli_agent.py
+++ b/rift-engine/rift/agents/cli_agent.py
@@ -38,7 +38,7 @@ from rift.agents.util import stream_string, stream_string_ascii, ainput
 @dataclass
 class ClientParams:
     """
-    Base class for special parameters for instances of `CliAgent`.
+    Base class for special parameters for instances of `Agent`.
     Subclass to add agent-specific attributes.
 
     Attributes:
@@ -51,14 +51,14 @@ class ClientParams:
 
 
 @dataclass
-class CliAgent:
+class Agent:
     """
     Abstract base class for agents that can be interacted with through a CLI
     and which produce code diffs that can be sent to an LSP server.
 
     To implement your own agent:
     - create another file in this directory
-    - subclass `CliAgent`
+    - subclass `Agent`
     - run it as a Python script with `launcher` as the entrypoint from inside a VSCode terminal (if using the Rift VSCode extension). see `smol.py` for an example.
 
     Attributes:
@@ -190,7 +190,7 @@ async def main(agent_cls, params):
     await t
 
 
-def launcher(agent_cls: Type[CliAgent], param_cls: Type[ClientParams]):
+def launcher(agent_cls: Type[Agent], param_cls: Type[ClientParams]):
     import fire
 
     params = fire.Fire(get_dataclass_function(param_cls))

--- a/rift-engine/rift/agents/cli_agent.py
+++ b/rift-engine/rift/agents/cli_agent.py
@@ -143,7 +143,7 @@ async def main(agent_cls, params):
             self.stats["changed_files"] = list()
 
         def elapsed(self):
-            return time.time() - start
+            return time.time() - self._start
 
         def report_stats(self):
             self.stats

--- a/rift-engine/rift/agents/cli_agent.py
+++ b/rift-engine/rift/agents/cli_agent.py
@@ -8,16 +8,18 @@ import pickle as pkl
 from dataclasses import dataclass, field
 from typing import Any, AsyncIterable, ClassVar, Dict, List, Optional, Type
 
-import rift.agents.file_diff as file_diff
+import rift.util.file_diff as file_diff
 import rift.lsp.types as lsp
 import rift.server.core as core
 import rift.server.lsp as server
+
 import smol_dev
 import tqdm.asyncio
+
 from rich.console import Console
 from rich.logging import RichHandler
 from rich.panel import Panel
-from rift.agents.abstract import AgentRegistryResult
+
 from rift.lsp.types import InitializeParams
 from rift.rpc.io_transport import AsyncStreamTransport
 from rift.rpc.jsonrpc import RpcServer, rpc_method, rpc_request
@@ -30,7 +32,7 @@ import types
 
 import art
 import fire
-from rift.agents.client.util import stream_string, stream_string_ascii
+from rift.agents.util import stream_string, stream_string_ascii
 
 
 @dataclass

--- a/rift-engine/rift/agents/cli_agent.py
+++ b/rift-engine/rift/agents/cli_agent.py
@@ -139,16 +139,18 @@ async def main(agent_cls, params):
         stats: Dict[Any, Any] = field(default_factory=dict)
 
         def __post_init__(self):
+            self.stats["elapsed_time"] = None
             self.stats["changed_files"] = list()
         
         def elapsed(self):
             return time.time() - start
 
         def report_stats(self):
+            stats = self.stats
             console.print(
                 Panel(
-                    json.dumps(
-                        self.stats, indent=2
+                    "[AgentRunStats] report:\n" + json.dumps(
+                        stats, indent=2
                     )
                 )
             )
@@ -164,6 +166,9 @@ async def main(agent_cls, params):
                 label="rift",
             )
         )
+    agent_stats.stats["elapsed_time"] = agent_stats.elapsed
+
+    console.print("\n")
         
     agent_stats.report_stats()
 

--- a/rift-engine/rift/agents/cli_agent.py
+++ b/rift-engine/rift/agents/cli_agent.py
@@ -139,7 +139,7 @@ async def main(agent_cls, params):
         stats: Dict[Any, Any] = field(default_factory=dict)
 
         def __post_init__(self):
-            stats["changed_files"] = set()
+            self.stats["changed_files"] = list()
         
         def elapsed(self):
             return time.time() - start

--- a/rift-engine/rift/agents/cli_agent.py
+++ b/rift-engine/rift/agents/cli_agent.py
@@ -136,7 +136,7 @@ async def main(agent_cls, params):
     @dataclass
     class AgentRunStats:
         _start: float = field(default_factory=time.time)
-        stats: Dict[Any. Any] = field(default_factory=dict)
+        stats: Dict[Any, Any] = field(default_factory=dict)
 
         def __post_init__(self):
             stats["changed_files"] = set()

--- a/rift-engine/rift/agents/smol.py
+++ b/rift-engine/rift/agents/smol.py
@@ -86,7 +86,7 @@ class SmolAgent(CliAgent):
 
             stream_string(chunk.decode("utf-8"))
 
-        plan = smol_dev.plan(prompt, streamHandler=stream_handler, model=params.model)
+        plan = smol_dev.plan(prompt, stream_handler=stream_handler, model=params.model)
 
         logger.info("Running with plan:")
         self.console.print(plan, emoji=True, markup=True)
@@ -121,7 +121,7 @@ class SmolAgent(CliAgent):
         async def generate_code_for_filepath(file_path: str, position: int) -> file_diff.FileChange:
             stream_handler = lambda chunk: pbar.update(n=len(chunk))
             code_future = asyncio.ensure_future(
-                smol_dev.generate_code(prompt, plan, file_path, streamHandler=stream_handler, model=params.model)
+                smol_dev.generate_code(prompt, plan, file_path, stream_handler=stream_handler, model=params.model)
             )
             with tqdm.asyncio.tqdm(position=position, unit=" chars", unit_scale=True) as pbar:
                 async with updater.lock:

--- a/rift-engine/rift/agents/smol.py
+++ b/rift-engine/rift/agents/smol.py
@@ -30,7 +30,7 @@ import types
 
 import art
 import fire
-from rift.agents.cli_agent import CliAgent, ClientParams, launcher
+from rift.agents.cli_agent import Agent, ClientParams, launcher
 from rift.agents.util import ainput
 
 import smol_dev
@@ -52,10 +52,10 @@ class SmolAgentClientParams(ClientParams):
 
 
 @dataclass
-class SmolAgent(CliAgent):
+class SmolAgent(Agent):
     """
     This class represents the SmolAgent, which is a CLI agent that generates code based on a given prompt.
-    It inherits from the CliAgent class.
+    It inherits from the Agent class.
 
     Attributes:
     name: ClassVar[str] - The name of the agent. For SmolAgent, it is "smol".

--- a/rift-engine/rift/agents/smol.py
+++ b/rift-engine/rift/agents/smol.py
@@ -167,5 +167,5 @@ class SmolAgent(CliAgent):
         yield await asyncio.gather(*fs)
 
 
-# if __name__ == "__main__":
-#     launcher(SmolAgent, SmolAgentClientParams)
+if __name__ == "__main__":
+    launcher(SmolAgent, SmolAgentClientParams)

--- a/rift-engine/rift/agents/smol.py
+++ b/rift-engine/rift/agents/smol.py
@@ -7,17 +7,17 @@ import os
 import pickle as pkl
 from dataclasses import dataclass, field
 from typing import Any, AsyncIterable, ClassVar, Dict, List, Optional, Type
-
-import rift.agents.file_diff as file_diff
-import rift.lsp.types as lsp
-import rift.server.core as core
-import rift.server.lsp as server
-import smol_dev
 import tqdm.asyncio
+
 from rich.console import Console
 from rich.logging import RichHandler
 from rich.panel import Panel
-from rift.agents.abstract import AgentRegistryResult
+
+
+import rift.util.file_diff as file_diff
+import rift.lsp.types as lsp
+import rift.server.core as core
+import rift.server.lsp as server
 from rift.lsp.types import InitializeParams
 from rift.rpc.io_transport import AsyncStreamTransport
 from rift.rpc.jsonrpc import RpcServer, rpc_method, rpc_request
@@ -30,9 +30,10 @@ import types
 
 import art
 import fire
-from rift.agents.client.cli_agent import CliAgent, ClientParams, launcher
-from rift.agents.client.util import ainput
+from rift.agents.cli_agent import CliAgent, ClientParams, launcher
+from rift.agents.util import ainput
 
+import smol_dev
 
 @dataclass
 class SmolAgentClientParams(ClientParams):
@@ -166,5 +167,5 @@ class SmolAgent(CliAgent):
         yield await asyncio.gather(*fs)
 
 
-if __name__ == "__main__":
-    launcher(SmolAgent, SmolAgentClientParams)
+# if __name__ == "__main__":
+#     launcher(SmolAgent, SmolAgentClientParams)

--- a/rift-engine/rift/agents/smol.py
+++ b/rift-engine/rift/agents/smol.py
@@ -37,6 +37,15 @@ import smol_dev
 
 @dataclass
 class SmolAgentClientParams(ClientParams):
+    """
+    This class is used to specify the parameters for the SmolAgent.
+    It inherits from the ClientParams class.
+
+    Attributes:
+    prompt_file: Optional[str] - The path to the prompt file. If not provided, the user will be asked to input a prompt.
+    debug: bool - A flag to indicate whether the application is in debug mode. Default is False.
+    model: Literal["gpt-3.5-turbo-0613", "gpt-4-0613"] - The model to be used. Default is "gpt-3.5-turbo-0613".
+    """
     prompt_file: Optional[str] = None  # path to prompt file
     debug: bool = False
     model: Literal["gpt-3.5-turbo-0613", "gpt-4-0613"] = "gpt-3.5-turbo-0613"
@@ -44,6 +53,15 @@ class SmolAgentClientParams(ClientParams):
 
 @dataclass
 class SmolAgent(CliAgent):
+    """
+    This class represents the SmolAgent, which is a CLI agent that generates code based on a given prompt.
+    It inherits from the CliAgent class.
+
+    Attributes:
+    name: ClassVar[str] - The name of the agent. For SmolAgent, it is "smol".
+    run_params: Type[SmolAgentClientParams] - The parameters for running the agent. It uses the SmolAgentClientParams class.
+    splash: Optional[str] - The splash screen for the agent. It is a string of ASCII art.
+    """
     name: ClassVar[str] = "smol"
     run_params: Type[SmolAgentClientParams] = SmolAgentClientParams
     splash: Optional[

--- a/rift-engine/rift/agents/smol.py
+++ b/rift-engine/rift/agents/smol.py
@@ -93,7 +93,7 @@ class SmolAgent(CliAgent):
 
         await ainput("\n> Press any key to continue.\n")
 
-        file_paths = smol_dev.specify_filePaths(prompt, plan, model=params.model)
+        file_paths = smol_dev.specify_file_paths(prompt, plan, model=params.model)
 
         logger.info("Got file paths:")
         self.console.print(json.dumps(file_paths, indent=2), markup=True)

--- a/rift-engine/rift/agents/util.py
+++ b/rift-engine/rift/agents/util.py
@@ -9,7 +9,6 @@ from concurrent.futures import ThreadPoolExecutor
 from dataclasses import dataclass, field
 from typing import Any, AsyncIterable, ClassVar, Dict, List, Optional, Type
 
-import rift.agents.file_diff as file_diff
 import rift.lsp.types as lsp
 import rift.server.core as core
 import rift.server.lsp as server
@@ -18,7 +17,6 @@ import tqdm.asyncio
 from rich.console import Console
 from rich.logging import RichHandler
 from rich.panel import Panel
-from rift.agents.abstract import AgentRegistryResult
 from rift.lsp.types import InitializeParams
 from rift.rpc.io_transport import AsyncStreamTransport
 from rift.rpc.jsonrpc import RpcServer, rpc_method, rpc_request

--- a/rift-engine/rift/agents/util.py
+++ b/rift-engine/rift/agents/util.py
@@ -32,6 +32,14 @@ import fire.core
 
 
 def _PrintResult(component_trace, verbose=False, serialize=None):
+    """
+    Prints the result of a Fire command.
+
+    Args:
+        component_trace: The component trace of the Fire command.
+        verbose: Whether to print verbose output. Default is False.
+        serialize: A function to serialize the result. If not None, it must be callable. Default is None.
+    """
     result = component_trace.GetResult()
     if serialize:
         if not callable(serialize):
@@ -68,17 +76,38 @@ fire.core._PrintResult = _PrintResult
 
 
 def stream_string(string):
+    """
+    Prints a string character by character with a delay between each character.
+
+    Args:
+        string: The string to print.
+    """
     for char in string:
         print(char, end="", flush=True)
         time.sleep(0.0015)
 
 
 def stream_string_ascii(name: str):
+    """
+    Prints an ASCII art representation of a string character by character with a delay between each character.
+
+    Args:
+        name: The string to convert to ASCII art and print.
+    """
     _splash = art.text2art(name, font="smslant")
 
     stream_string(_splash)
 
 
 async def ainput(prompt: str = "") -> str:
+    """
+    Asynchronously waits for user input.
+
+    Args:
+        prompt: The prompt to display to the user. Default is an empty string.
+
+    Returns:
+        The user's input as a string.
+    """
     with ThreadPoolExecutor(1, "AsyncInput") as executor:
         return await asyncio.get_event_loop().run_in_executor(executor, input, prompt)

--- a/rift-engine/rift/rpc/jsonrpc.py
+++ b/rift-engine/rift/rpc/jsonrpc.py
@@ -495,7 +495,7 @@ class RpcServer:
         # [todo] allow inheriting classes to do things here.
         await self.notify("initialized", None)
 
-    async def serve_forever(self, init_param=None):
+    async def listen_forever(self, init_param=None):
         """Runs forever. Serves your client.
 
         It will return when:

--- a/rift-engine/rift/server/core.py
+++ b/rift-engine/rift/server/core.py
@@ -101,6 +101,18 @@ class CodeCapabilitiesServer:
         transport = AsyncStreamTransport(reader, writer)
         await self.run_lsp(transport)
 
+    async def _run_forever_fut(self):
+        """Runs the language server.
+
+        If lsp_port = 'stdio', then the LSP listens on stdin and stdout.
+        There is also a web server at 7787 that the webview can connect to.
+        """
+        lsp_task = asyncio.create_task(
+            self.run_lsp_stdio() if self.lsp_port == "stdio" else self.run_lsp_tcp()
+        )
+        return lsp_task
+
+
     async def run_forever(self):
         """Runs the language server.
 
@@ -108,11 +120,9 @@ class CodeCapabilitiesServer:
         There is also a web server at 7787 that the webview can connect to.
         """
         loop = asyncio.get_event_loop()
-        lsp_task = loop.create_task(
-            self.run_lsp_stdio() if self.lsp_port == "stdio" else self.run_lsp_tcp()
-        )
+        lsp_task = await self._run_forever_fut()
         await lsp_task
-        logger.debug(f"exiting {type(self).__name__}.listen_forever")
+        logger.debug(f"exiting {type(self).__name__}.listen_forever")        
 
 
 def create_metaserver(

--- a/rift-engine/rift/server/core.py
+++ b/rift-engine/rift/server/core.py
@@ -101,7 +101,7 @@ class CodeCapabilitiesServer:
         transport = AsyncStreamTransport(reader, writer)
         await self.run_lsp(transport)
 
-    async def run_forever(self):
+    async def listen_forever(self):
         """Runs the language server.
 
         If lsp_port = 'stdio', then the LSP listens on stdin and stdout.
@@ -112,14 +112,14 @@ class CodeCapabilitiesServer:
             self.run_lsp_stdio() if self.lsp_port == "stdio" else self.run_lsp_tcp()
         )
         await lsp_task
-        logger.debug(f"exiting {type(self).__name__}.run_forever")
+        logger.debug(f"exiting {type(self).__name__}.listen_forever")
 
 
 def create_metaserver(
     port: LspPort = 7797,
     version=False,
     debug=False,
-) -> LspServer:
+) -> CodeCapabilitiesServer:
     """
     Main entry point for the rift server
     Args:
@@ -157,7 +157,7 @@ def main(
         debug=False,
 ):
     metaserver = create_metaserver(port, version, debug)
-    asyncio.run(metaserver.run_forever(), debug=debug)
+    asyncio.run(metaserver.listen_forever(), debug=debug)
 
 
 if __name__ == "__main__":

--- a/rift-engine/rift/server/core.py
+++ b/rift-engine/rift/server/core.py
@@ -101,7 +101,7 @@ class CodeCapabilitiesServer:
         transport = AsyncStreamTransport(reader, writer)
         await self.run_lsp(transport)
 
-    async def listen_forever(self):
+    async def run_forever(self):
         """Runs the language server.
 
         If lsp_port = 'stdio', then the LSP listens on stdin and stdout.
@@ -157,7 +157,7 @@ def main(
         debug=False,
 ):
     metaserver = create_metaserver(port, version, debug)
-    asyncio.run(metaserver.listen_forever(), debug=debug)
+    asyncio.run(metaserver.run_forever(), debug=debug)
 
 
 if __name__ == "__main__":

--- a/rift-engine/rift/util/file_diff.py
+++ b/rift-engine/rift/util/file_diff.py
@@ -1,0 +1,104 @@
+import os
+from dataclasses import dataclass
+from typing import List, Tuple, Dict, Optional, Any
+
+import rift.lsp.types as lsp
+
+from diff_match_patch import diff_match_patch
+
+from rift.lsp import (
+    CreateFile,
+    Range,
+    TextDocumentEdit,
+    TextDocumentIdentifier,
+    TextEdit,
+    WorkspaceEdit,
+)
+from rift.lsp.types import ChangeAnnotation
+
+
+@dataclass
+class FileChange:
+    uri: TextDocumentIdentifier
+    old_content: str
+    new_content: str
+    description: Optional[str] = None
+    is_new_file: bool = False
+
+
+def get_file_change(path: str, new_content: str) -> FileChange:
+    uri = TextDocumentIdentifier(uri="file://" + path, version=0)
+    if os.path.isfile(path):
+        with open(path, "r") as f:
+            old_content = f.read()
+            return FileChange(uri=uri, old_content=old_content, new_content=new_content)
+    else:
+        return FileChange(uri=uri, old_content="", new_content=new_content, is_new_file=True)
+
+
+def edits_from_file_change(file_change: FileChange, user_confirmation: bool = False) -> WorkspaceEdit:
+    dmp = diff_match_patch()
+    diff = dmp.diff_main(file_change.old_content, file_change.new_content)
+
+    line = 0  # current line number
+    char = 0  # current character position within the line
+    edits = []  # list of TextEdit objects
+
+    for op, text in diff:
+        # count the number of lines in `text` and the number of characters in the last line
+        lines = text.split("\n")
+        last_line_chars = len(lines[-1])
+        line_count = len(lines) - 1  # don't count the current line
+
+        end_line = line + line_count
+        end_char = (
+            char + last_line_chars if line_count == 0 else last_line_chars
+        )  # if we moved to a new line, start at char 0
+
+        if op == -1:
+            # text was deleted
+            edits.append(TextEdit(Range.mk(line, char, end_line, end_char), "", annotationId="rift"))
+        elif op == 1:
+            # text was added
+            edits.append(
+                TextEdit(Range.mk(line, char, line, char), text, annotationId="rift")
+            )  # new text starts at the current position
+
+        # update position
+        line = end_line
+        char = end_char
+
+    documentChanges = []
+
+    changeAnnotations: dict[lsp.ChangeAnnotationIdentifier, lsp.ChangeAnnotation] = dict()
+    if file_change.is_new_file:
+        documentChanges.append(CreateFile(kind="create", uri=file_change.uri.uri, annotationId="rift"))
+    documentChanges.append(TextDocumentEdit(textDocument=file_change.uri, edits=edits))
+    changeAnnotations["rift"] = lsp.ChangeAnnotation(label="rift", needsConfirmation=user_confirmation, description=None)
+    return WorkspaceEdit(documentChanges=documentChanges, changeAnnotations=changeAnnotations)
+
+
+def edits_from_file_changes(file_changes: List[FileChange], user_confirmation: bool = False) -> WorkspaceEdit:
+    documentChanges: List[Union[lsp.TextDocumentEdit, lsp.CreateFile, lsp.RenameFile, lsp.DeleteFile]] = []
+    changeAnnotations: Dict[ChangeAnnotationIdentifier, ChangeAnnotation] = dict()
+    for file_change in file_changes:
+        edit = edits_from_file_change(file_change=file_change, user_confirmation=user_confirmation)
+        documentChanges += edit.documentChanges
+        if edit.changeAnnotations is not None:
+            changeAnnotations.update(edit.changeAnnotations)
+    return WorkspaceEdit(documentChanges=documentChanges, changeAnnotations=changeAnnotations)
+
+
+if __name__ == "__main__":
+    file1 = "tests/diff/file1.txt"
+    file2 = "tests/diff/file2.txt"
+    with open(file1, "r") as f1, open(file2, "r") as f2:
+        uri = TextDocumentIdentifier(uri="file://" + file1, version=0)
+        file_change = get_file_change(path=file1, new_content=f2.read())
+        workspace_edit = edits_from_file_change(file_change=file_change)
+        print(f"\nworkspace_edit: {workspace_edit}\n")
+        dummy_path = "dummy.txt"
+        dummy_content = "dummy content"
+        file_change = get_file_change(path=dummy_path, new_content=dummy_content)
+        workspace_edit = edits_from_file_change(file_change=file_change)
+        print(f"\ntest_new_file: {workspace_edit}\n")


### PR DESCRIPTION
Add an interface for third-party coding assistant agents defined in Python to connect to the Rift Code Engine and propose workspace edits directly to VSCode.

```python
@dataclass
class CliAgent:
    """
    Abstract base class for agents that can be interacted with through a CLI
    and which produce code diffs that can be sent to an LSP server.

    To implement your own agent:
    - create another file in this directory
    - subclass `CliAgent`
    - run it as a Python script with `launcher` as the entrypoint from inside a VSCode terminal (if using the Rift VSCode extension). see `smol.py` for an example.
    """
```