### PR TITLE
Rift Agents API: add support for `gpt-engineer`

### DIFF
--- a/editors/rift-vscode/README.md
+++ b/editors/rift-vscode/README.md
@@ -5,6 +5,13 @@ Rift and this extension are fully [open-source](https://github.com/morph-labs/ri
 ## About
 The future of AI code assistants is open-source, private, secure, and on-device. Rift understands, explains, and writes code with language models that run entirely on your device using the open source [Rift Code Engine](https://github.com/morph-labs/rift/tree/main/rift-engine).
 
+## Installation
+Install the VSCode extension from the VSCode Marketplace or by building and installing from the VSIX bundle produced by the following steps:
+
+- Increment the semver number (e.g. 0.0.8 to 0.0.9) in the `package.json`
+- run `vsce package`
+- Install from the VSIX by searching "VSIX" from the VSCode command palette.
+
 ## Usage 
 1. Ensure the [Rift Code Engine](https://github.com/morph-labs/rift/tree/main/rift-engine) is installed and running on port 7797:
 

--- a/rift-engine/pyproject.toml
+++ b/rift-engine/pyproject.toml
@@ -3,6 +3,9 @@ requires = ["hatchling"]
 build-backend = "hatchling.build"
 
 
+[tool.hatch.metadata]
+allow-direct-references = true
+
 [project]
 name = "pyrift"
 description = ''
@@ -25,6 +28,7 @@ dependencies = [
   "transformers",
   "diff_match_patch",
   "art",
+  "gpt-engineer @ git+https://www.github.com/morph-labs/gpt-engineer"
 ]
 dynamic = ["version"]
 

--- a/rift-engine/rift/agents/README.md
+++ b/rift-engine/rift/agents/README.md
@@ -27,7 +27,7 @@ To add your own agent, you need to create a new file in this directory and subcl
 4. At the end of your file, call `launcher` with your agent class and parameters dataclass.
 
 ## Running Your Own Agent
-Use the `launcher` method defined in `cli_agent.py`. See `smol.py` for a reference implementation at the bottom of the file. Make sure the [Rift VSCode extension](../../../editors/rift-vscode/README.md) is installed and activated as well. Once configured, just run this from the VSCode terminal:
+Use the `launcher` method defined in `cli_agent.py`. See `smol.py` for a reference implementation at the bottom of the file. Make sure the [Rift VSCode extension](../../../editors/rift-vscode/README.md) is installed and activated as well. Ensure that any other Rift server processes have been killed (this will no longer be necessary after we resolve [this issue](https://www.github.com/morph-labs/rift/issues/62).) Once configured, just run this from the VSCode terminal:
 
 ```python
 # defined in ./my_agent.py

--- a/rift-engine/rift/agents/README.md
+++ b/rift-engine/rift/agents/README.md
@@ -27,7 +27,7 @@ To add your own agent, you need to create a new file in this directory and subcl
 4. At the end of your file, call `launcher` with your agent class and parameters dataclass.
 
 ## Running Your Own Agent
-Use the `launcher` method defined in `cli_agent.py`. See `smol.py` for a reference implementation at the bottom of the file. Once configured, just run this from the VSCode terminal:
+Use the `launcher` method defined in `cli_agent.py`. See `smol.py` for a reference implementation at the bottom of the file. Make sure the [Rift VSCode extension](../../../editors/rift-vscode/README.md) is installed and activated as well. Once configured, just run this from the VSCode terminal:
 
 ```python
 # defined in ./my_agent.py

--- a/rift-engine/rift/agents/README.md
+++ b/rift-engine/rift/agents/README.md
@@ -47,5 +47,5 @@ python -m rift.agents.smol --port 7797 --debug Faulse --prompt_file $PROMPT_FILE
 
 - `gpt-engineer`:
 ```python
-python -m rift.agents.gpt_eng --port 7797 --debug False --prompt $PROMPT_FILE --model gpt-4-0613
+python -m rift.agents.gpt_eng --port 7797 --debug False --model gpt-4-0613
 ```

--- a/rift-engine/rift/agents/README.md
+++ b/rift-engine/rift/agents/README.md
@@ -38,3 +38,14 @@ python -m rift.agents.my_agent --port 7797 --debug False # other agent-specific 
 
 - Please note that agents can run third-party code, do not use Rift's model abstractions, and are presently not configurable through the Rift extension settings in VSCode. Be careful when running agents with untrusted code.
 - Currently each agent spins up its own Rift instance. Once support for [multiple clients](https://www.github.com/morph-labs/rift/issues/62) is added, multiple agents can interact with a single Rift server.
+
+## Supported agents
+- `smol-developer`:
+```python
+python -m rift.agents.smol --port 7797 --debug Faulse --prompt_file $PROMPT_FILE --model gpt-4-0613
+```
+
+- `gpt-engineer`:
+```python
+python -m rift.agents.gpt_eng --port 7797 --debug False --prompt $PROMPT_FILE --model gpt-4-0613
+```

--- a/rift-engine/rift/agents/cli_agent.py
+++ b/rift-engine/rift/agents/cli_agent.py
@@ -193,5 +193,5 @@ async def main(agent_cls, params):
 def launcher(agent_cls: Type[Agent], param_cls: Type[ClientParams]):
     import fire
 
-    params = fire.Fire(get_dataclass_function(param_cls))
+    params = fire.Fire(param_cls)
     asyncio.run(main(agent_cls=agent_cls, params=params), debug=params.debug)

--- a/rift-engine/rift/agents/cli_agent.py
+++ b/rift-engine/rift/agents/cli_agent.py
@@ -31,7 +31,6 @@ import art
 import fire
 from rift.agents.util import ainput, stream_string, stream_string_ascii
 
-
 @dataclass
 class ClientParams:
     """
@@ -159,16 +158,17 @@ async def main(agent_cls, params):
                 console.print(Panel("[AgentRunStats] report:\n" + json.dumps(self.stats, indent=2)))
 
         agent_stats = AgentRunStats()
-
+        
         async for file_changes in agent.run():
             for file_change in file_changes:
                 agent_stats.stats["changed_files"].append(file_change.uri.uri)
             await client.server.apply_workspace_edit(
                 lsp.ApplyWorkspaceEditParams(
                     file_diff.edits_from_file_changes(file_changes, user_confirmation=True),
-                    label="rift",
+                    label=file_changes[0].description or "rift",
                 )
-            )
+            )        
+            
         agent_stats.stats["elapsed_time"] = agent_stats.elapsed()
 
         console.print("\n")

--- a/rift-engine/rift/agents/cli_agent.py
+++ b/rift-engine/rift/agents/cli_agent.py
@@ -8,18 +8,15 @@ import pickle as pkl
 from dataclasses import dataclass, field
 from typing import Any, AsyncIterable, ClassVar, Dict, List, Optional, Type
 
-import rift.util.file_diff as file_diff
 import rift.lsp.types as lsp
 import rift.server.core as core
 import rift.server.lsp as server
-
+import rift.util.file_diff as file_diff
 import smol_dev
 import tqdm.asyncio
-
 from rich.console import Console
 from rich.logging import RichHandler
 from rich.panel import Panel
-
 from rift.lsp.types import InitializeParams
 from rift.rpc.io_transport import AsyncStreamTransport
 from rift.rpc.jsonrpc import RpcServer, rpc_method, rpc_request
@@ -32,7 +29,7 @@ import types
 
 import art
 import fire
-from rift.agents.util import stream_string, stream_string_ascii, ainput
+from rift.agents.util import ainput, stream_string, stream_string_ascii
 
 
 @dataclass
@@ -80,7 +77,6 @@ class Agent:
         This method should be overridden by subclasses to provide the specific implementation.
         """
         ...
-
 
 
 def get_dataclass_function(cls):
@@ -160,13 +156,7 @@ async def main(agent_cls, params):
                 return time.time() - self._start
 
             def report_stats(self):
-                console.print(
-                    Panel(
-                        "[AgentRunStats] report:\n" + json.dumps(
-                            self.stats, indent=2
-                        )
-                    )
-                )
+                console.print(Panel("[AgentRunStats] report:\n" + json.dumps(self.stats, indent=2)))
 
         agent_stats = AgentRunStats()
 
@@ -184,13 +174,13 @@ async def main(agent_cls, params):
         console.print("\n")
 
         agent_stats.report_stats()
-        
+
         await ainput("\n> Press any key to restart.\n")
-        
+
     await t
 
 
-def launcher(agent_cls: Type[Agent], param_cls: Type[ClientParams]):
+def launcher(agent_cls: Type[Agent], param_cls: Type[ClientParams], loop=None):
     import fire
 
     params = fire.Fire(param_cls)

--- a/rift-engine/rift/agents/cli_agent.py
+++ b/rift-engine/rift/agents/cli_agent.py
@@ -31,6 +31,7 @@ import art
 import fire
 from rift.agents.util import ainput, stream_string, stream_string_ascii
 
+
 @dataclass
 class ClientParams:
     """
@@ -158,7 +159,7 @@ async def main(agent_cls, params):
                 console.print(Panel("[AgentRunStats] report:\n" + json.dumps(self.stats, indent=2)))
 
         agent_stats = AgentRunStats()
-        
+
         async for file_changes in agent.run():
             for file_change in file_changes:
                 agent_stats.stats["changed_files"].append(file_change.uri.uri)
@@ -167,8 +168,8 @@ async def main(agent_cls, params):
                     file_diff.edits_from_file_changes(file_changes, user_confirmation=True),
                     label=file_changes[0].description or "rift",
                 )
-            )        
-            
+            )
+
         agent_stats.stats["elapsed_time"] = agent_stats.elapsed()
 
         console.print("\n")

--- a/rift-engine/rift/agents/gpt_eng.py
+++ b/rift-engine/rift/agents/gpt_eng.py
@@ -140,11 +140,7 @@ class GPTEngineerAgent(agent.Agent):
         updates_queue = Queue()
 
         # Assign a new to_files function that passes updates to the queue.
-        def new_to_files(chat, workspace):
-            return to_files(chat, workspace, updates_queue)
-
-        gpt_engineer.chat_to_files.to_files = new_to_files
-
+        gpt_engineer.chat_to_files.to_files = lambda chat, workspace: to_files(chat, workspace, updates_queue)
         # Run main function in a separate thread and send updates from the queue.
         main_thread = threading.Thread(target=_main, kwargs=params_dict, daemon=True)
         main_thread.start()

--- a/rift-engine/rift/agents/gpt_eng.py
+++ b/rift-engine/rift/agents/gpt_eng.py
@@ -1,49 +1,56 @@
 import asyncio
+import inspect
 import threading
 import typing
-import inspect
 
 try:
     import gpt_engineer
+    import gpt_engineer.chat_to_files
+    import gpt_engineer.db
+    from gpt_engineer.ai import AI, fallback_model
+    from gpt_engineer.collect import collect_learnings
+    from gpt_engineer.db import DB, DBs, archive
+    from gpt_engineer.learning import collect_consent
+    from gpt_engineer.steps import STEPS
+    from gpt_engineer.steps import Config as StepsConfig
 except ImportError:
     raise Exception("`gpt_engineer` not found. Try `pip install gpt-engineer`")
 
-import rift.agents.cli_agent as agent
-import rift.util.file_diff as file_diff
-import rift.lsp.types as lsp
-import threading
+UPDATES_QUEUE = asyncio.Queue()
 
-from dataclasses import dataclass
+
+def to_files(chat, workspace: gpt_engineer.db.DB):
+    workspace["all_output.txt"] = chat
+    files = gpt_engineer.chat_to_files.parse_chat(chat)
+
+    async def _update_queue(item):
+        await UPDATES_QUEUE.put(item)
+
+    for file_name, file_content in files:
+        workspace[file_name] = file_content
+    asyncio.create_task(_update_queue(list(workspace.in_memory_dict.items())))
+
+
+# Assign a new to_files function that passes updates to the queue.
+gpt_engineer.chat_to_files.to_files = to_files
 
 import json
 import logging
-
+import queue
+import threading
+from dataclasses import dataclass
 from pathlib import Path
+from queue import Queue
 
+import rift.agents.cli_agent as agent
+import rift.lsp.types as lsp
+import rift.util.file_diff as file_diff
 import typer
 
-from gpt_engineer.ai import AI, fallback_model
-from gpt_engineer.collect import collect_learnings
-from gpt_engineer.db import DB, DBs, archive
-from gpt_engineer.learning import collect_consent
-from gpt_engineer.steps import STEPS, Config as StepsConfig
 
-from queue import Queue
-import queue
-
-def to_files(chat, workspace, updates_queue: queue.Queue):
-    print("TOFILES CALLED")
-    workspace["all_output.txt"] = chat
-    files = parse_chat(chat)
-    for file_name, file_content in files:
-        workspace[file_name] = file_content
-        print("WOAH")
-        updates_queue.put(workspace.copy())
-
-
-def _main(
-    project_path: str = typer.Argument("projects/example", help="path"),
-    model: str = typer.Argument("gpt-4", help="model id string"),
+async def _main(
+    project_path: str,
+    model: str,
     temperature: float = 0.1,
     steps_config: StepsConfig = typer.Option(
         StepsConfig.DEFAULT, "--steps", "-s", help="decide which steps to run"
@@ -68,7 +75,7 @@ def _main(
         memory=DB(memory_path),
         logs=DB(memory_path / "logs"),
         input=DB(input_path),
-        workspace=DB(workspace_path), #in_memory_dict={}),
+        workspace=DB(workspace_path, in_memory_dict={}),  # in_memory_dict={}),
         preprompts=DB(Path(gpt_engineer.__file__).parent / "preprompts"),
         archive=DB(archive_path),
     )
@@ -91,6 +98,7 @@ def _main(
     # dbs.logs["token_usage"] = ai.format_token_usage_log()
     return dbs.workspace
 
+
 @dataclass
 class GPTEngineerAgentParams(agent.ClientParams):
     project_path: str = "projects/example"
@@ -99,13 +107,14 @@ class GPTEngineerAgentParams(agent.ClientParams):
     steps_config: gpt_engineer.steps.Config = "default"
     verbose: bool = False
 
+
 @dataclass
 class GPTEngineerAgent(agent.Agent):
     name: str = "gpt-engineer"
     run_params: typing.Type[agent.ClientParams] = GPTEngineerAgentParams
     splash: typing.Optional[
         str
-        ] = """\
+    ] = """\
 
 
 
@@ -136,24 +145,18 @@ class GPTEngineerAgent(agent.Agent):
 
         params_dict = {k: v for k, v in iter_fields(self.run_params)}
 
-        # Create a queue for updates.
-        updates_queue = Queue()
+        main_t = asyncio.create_task(_main(**params_dict))
 
-        # Assign a new to_files function that passes updates to the queue.
-        gpt_engineer.chat_to_files.to_files = lambda chat, workspace: to_files(chat, workspace, updates_queue)
-        # Run main function in a separate thread and send updates from the queue.
-        main_thread = threading.Thread(target=_main, kwargs=params_dict, daemon=True)
-        main_thread.start()
-
-        while main_thread.is_alive():
+        while not main_t.done():
             try:
-                # Try to get update from the queue with a timeout.
-                workspace = updates_queue.get(timeout=1.0)
-                yield [file_diff.get_file_change(file_path, new_contents) 
-                    for file_path, new_contents in workspace.items()]
-            except queue.Empty:
-                # If the queue is empty, just continue to the next iteration.
+                updates = await asyncio.wait_for(UPDATES_QUEUE.get(), 1.0)
+                yield [
+                    file_diff.get_file_change(file_path, new_contents)
+                    for file_path, new_contents in updates
+                ]
+            except asyncio.TimeoutError:
                 continue
+
 
 if __name__ == "__main__":
     agent.launcher(GPTEngineerAgent, GPTEngineerAgentParams)

--- a/rift-engine/rift/agents/gpt_eng.py
+++ b/rift-engine/rift/agents/gpt_eng.py
@@ -139,29 +139,26 @@ class GPTEngineerAgentParams(agent.ClientParams):
 class GPTEngineerAgent(agent.Agent):
     name: str = "gpt-engineer"
     run_params: typing.Type[agent.ClientParams] = GPTEngineerAgentParams
-    splash: typing.Optional[
+    splash :typing.Optional[
         str
     ] = """\
 
 
-
-                █████████          ██████  ██████  ████████
-             █████   ████         ██       ██   ██    ██
-           ████   ████      ██    ██   ███ ██████     ██
-          ███    ███     ██████   ██    ██ ██         ██
-          ███     █████████ ███    ██████  ██         ██
-           ███      ████   ████
-         ████             ███
-      ████    █████████████       ███████ ███    ██  ██████
-   █████    ████                  ██      ████   ██ ██
-  ███     ████                    █████   ██ ██  ██ ██   ███
-  ███   ███                       ██      ██  ██ ██ ██    ██
-   ██████                         ███████ ██   ████  ██████
-
+   _____ _____ _______                 ⣀⣀⣀⡀
+  / ____|  __ \__   __|             ⣰⣾⣿⣿⣿⠟⠁
+ | |  __| |__) | | |               ⣼⣿⣿⣿⡟⠁    ⢀
+ | | |_ |  ___/  | |              ⠐⣿⣿⣿⣿⡆   ⢀⣴⣿⡇
+ | |__| | |      | |              ⢈⣿⣿⣿⣿⣷⣶⣶⣶⣿⣿⣿⠃
+  \_____|_|  _  _|_|_           ⢀⣴⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⡿⠋
+ |  ____| \ | |/ ____|        ⢀⣴⣿⣿⣿⣿⣿⣿⠟⠛⠟⠛⠛⠉
+ | |__  |  \| | |  __       ⢀⣴⣿⣿⣿⣿⣿⣿⠟⠁
+ |  __| | . ` | | |_ |    ⢀⣴⣿⣿⣿⣿⣿⣿⠟⠁
+ | |____| |\  | |__| |   ⢰⣿⠟⠻⣿⣿⣿⠟⠁
+ |______|_| \_|\_____|   ⠸⣿⣦⣴⣿⠟⠁
+                          ⠈⠉⠉
 
 
-
-"""
+    """
 
     async def run(self) -> typing.AsyncIterable[typing.List[file_diff.FileChange]]:
         from dataclasses import dataclass, fields

--- a/rift-engine/rift/agents/gpt_eng.py
+++ b/rift-engine/rift/agents/gpt_eng.py
@@ -25,9 +25,13 @@ from gpt_engineer.db import DB, DBs, archive
 from gpt_engineer.learning import collect_consent
 from gpt_engineer.steps import STEPS, Config as StepsConfig
 
-to_update = []
-def me(res):
-    to_update.add(res)
+def to_files(chat, workspace, queue: asyncio.Queue):
+    workspace["all_output.txt"] = chat
+    files = parse_chat(chat)
+    for file_name, file_content in files:
+        workspace[file_name] = file_content
+        queue.put_nowait(workspace)
+
 
 def _main(
     project_path: str = typer.Argument("projects/example", help="path"),

--- a/rift-engine/rift/agents/gpt_eng.py
+++ b/rift-engine/rift/agents/gpt_eng.py
@@ -6,13 +6,7 @@ import typing
 try:
     import gpt_engineer
     import gpt_engineer.chat_to_files
-    import gpt_engineer.db
-    from gpt_engineer.ai import AI, fallback_model
-    from gpt_engineer.collect import collect_learnings
-    from gpt_engineer.db import DB, DBs, archive
-    from gpt_engineer.learning import collect_consent
-    from gpt_engineer.steps import STEPS
-    from gpt_engineer.steps import Config as StepsConfig
+    import gpt_engineer.db    
 except ImportError:
     raise Exception("`gpt_engineer` not found. Try `pip install gpt-engineer`")
 
@@ -33,6 +27,13 @@ def to_files(chat, workspace: gpt_engineer.db.DB):
 
 # Assign a new to_files function that passes updates to the queue.
 gpt_engineer.chat_to_files.to_files = to_files
+
+from gpt_engineer.ai import AI, fallback_model
+from gpt_engineer.collect import collect_learnings
+from gpt_engineer.db import DB, DBs, archive
+from gpt_engineer.learning import collect_consent
+from gpt_engineer.steps import STEPS
+from gpt_engineer.steps import Config as StepsConfig
 
 import json
 import logging

--- a/rift-engine/rift/agents/gpt_eng.py
+++ b/rift-engine/rift/agents/gpt_eng.py
@@ -76,8 +76,8 @@ async def _main(
     steps = STEPS[steps_config]
     # async def execute_steps():
 
-
     from concurrent import futures
+
     with futures.ThreadPoolExecutor(1) as pool:
         for step in steps:
             await asyncio.sleep(0.1)
@@ -94,6 +94,7 @@ async def _main(
                         SEEN.add(x[0])
             await asyncio.sleep(0.5)
 
+
 @dataclass
 class GPTEngineerAgentParams(agent.ClientParams):
     project_path: str = "projects/example"
@@ -107,7 +108,7 @@ class GPTEngineerAgentParams(agent.ClientParams):
 class GPTEngineerAgent(agent.Agent):
     name: str = "gpt-engineer"
     run_params: typing.Type[agent.ClientParams] = GPTEngineerAgentParams
-    splash :typing.Optional[
+    splash: typing.Optional[
         str
     ] = """\
 
@@ -145,7 +146,9 @@ class GPTEngineerAgent(agent.Agent):
             try:
                 updates = await asyncio.wait_for(UPDATES_QUEUE.get(), 1.0)
                 yield [
-                    file_diff.get_file_change(file_path, new_contents, annotation_label=str(counter))
+                    file_diff.get_file_change(
+                        file_path, new_contents, annotation_label=str(counter)
+                    )
                     for file_path, new_contents in updates
                 ]
             except asyncio.TimeoutError:

--- a/rift-engine/rift/agents/gpt_eng.py
+++ b/rift-engine/rift/agents/gpt_eng.py
@@ -93,15 +93,14 @@ async def _main(
         # then all the files and `run.sh` should be SAVED before you accept the proposal to run the entrypoint
         await asyncio.sleep(0.1)
         dbs.logs[step.__name__] = json.dumps(messages)
-        
         items = list(dbs.workspace.in_memory_dict.items())
         if len([x for x in items if x[0] not in SEEN]) > 0:
             await UPDATES_QUEUE.put([x for x in items if x[0] not in SEEN])
             for x in items:
-                if x[0] in SEEN:
+                if hash(x) in SEEN:
                     pass
                 else:
-                    SEEN.add(x[0])
+                    SEEN.add(hash(x))
         await asyncio.sleep(0.5)
 
         # TODO(pranav): uncomment this and increase the sleep duration as needed to make sure you can approve all the diffs before the entrypoint is generated --- this delays the appearance of the "run_entrypoint" step

--- a/rift-engine/rift/agents/gpt_eng.py
+++ b/rift-engine/rift/agents/gpt_eng.py
@@ -92,7 +92,7 @@ async def _main(
     with futures.ThreadPoolExecutor(1) as pool:
         for step in steps:
             await asyncio.sleep(0.1)
-            messages = await loop.run_in_executor(pool, step, ai, dbs)
+            messages = await asyncio.get_running_loop().run_in_executor(pool, step, ai, dbs)
             # messages = step(ai, dbs) # when `step.__name__` == `gen_entrypoint`, this proposes another diff for the `run.sh` shell script that you will also want to accept
             # then all the files and `run.sh` should be SAVED before you accept the proposal to run the entrypoint
             await asyncio.sleep(0.1)

--- a/rift-engine/rift/agents/gpt_eng.py
+++ b/rift-engine/rift/agents/gpt_eng.py
@@ -72,8 +72,6 @@ def _main(
         preprompts=DB(Path(gpt_engineer.__file__).parent / "preprompts"),
         archive=DB(archive_path),
     )
-    gpt_engineer.chat_to_files.to_files = lambda chat, workspace: to_files(chat, workspace, updates_queue)
-
 
     if steps_config not in [
         StepsConfig.EXECUTE_ONLY,
@@ -140,10 +138,13 @@ class GPTEngineerAgent(agent.Agent):
 
         # Create a queue for updates.
         updates_queue = Queue()
-        print(inspect.getsource(gpt_engineer.chat_to_files.to_files))
-        gpt_engineer.chat_to_files.to_files = lambda chat, workspace: to_files(chat, workspace, updates_queue)
-        print(inspect.getsource(gpt_engineer.chat_to_files.to_files))
-        print("TEST")
+
+        # Assign a new to_files function that passes updates to the queue.
+        def new_to_files(chat, workspace):
+            return to_files(chat, workspace, updates_queue)
+
+        gpt_engineer.chat_to_files.to_files = new_to_files
+
         # Run main function in a separate thread and send updates from the queue.
         main_thread = threading.Thread(target=_main, kwargs=params_dict, daemon=True)
         main_thread.start()

--- a/rift-engine/rift/agents/gpt_eng.py
+++ b/rift-engine/rift/agents/gpt_eng.py
@@ -1,0 +1,123 @@
+import typing
+try:
+    import gpt_engineer
+except ImportError:
+    raise Exception("`gpt_engineer` not found. Try `pip install gpt-engineer`")
+
+import rift.agents.cli_agent as agent
+import rift.util.file_diff as file_diff
+import rift.lsp.types as lsp
+
+from dataclasses import dataclass
+
+import json
+import logging
+
+from pathlib import Path
+
+import typer
+
+from gpt_engineer.ai import AI, fallback_model
+from gpt_engineer.collect import collect_learnings
+from gpt_engineer.db import DB, DBs, archive
+from gpt_engineer.learning import collect_consent
+from gpt_engineer.steps import STEPS, Config as StepsConfig
+
+RESULT = None
+
+def _main(
+    project_path: str = typer.Argument("projects/example", help="path"),
+    model: str = typer.Argument("gpt-4", help="model id string"),
+    temperature: float = 0.1,
+    steps_config: StepsConfig = typer.Option(
+        StepsConfig.DEFAULT, "--steps", "-s", help="decide which steps to run"
+    ),
+    verbose: bool = typer.Option(False, "--verbose", "-v"),
+    **kwargs,
+) -> DBs:
+    logging.basicConfig(level=logging.DEBUG if verbose else logging.INFO)
+
+    model = fallback_model(model)
+    ai = AI(
+        model=model,
+        temperature=temperature,
+    )
+
+    input_path = Path(project_path).absolute()
+    memory_path = input_path / "memory"
+    workspace_path = input_path / "workspace"
+    archive_path = input_path / "archive"
+
+    dbs = DBs(
+        memory=DB(memory_path),
+        logs=DB(memory_path / "logs"),
+        input=DB(input_path),
+        workspace=DB(workspace_path),
+        preprompts=DB(Path(__file__).parent / "preprompts"),
+        archive=DB(archive_path),
+    )
+
+    if steps_config not in [
+        StepsConfig.EXECUTE_ONLY,
+        StepsConfig.USE_FEEDBACK,
+        StepsConfig.EVALUATE,
+    ]:
+        archive(dbs)
+
+    steps = STEPS[steps_config]
+    for step in steps:
+        messages = step(ai, dbs)
+        dbs.logs[step.__name__] = json.dumps(messages)
+
+    if collect_consent():
+        collect_learnings(model, temperature, steps, dbs)
+
+    dbs.logs["token_usage"] = ai.format_token_usage_log()
+    RESULT = dbs.workspace
+
+@dataclass
+class GPTEngineerAgentParams(agent.ClientParams):
+    project_path: str = "projects/example"
+    model: str = "gpt-4"
+    temperature: float = 0.1
+    steps_config: gpt_engineer.steps.Config = "default"
+    verbose: bool = False
+
+@dataclass
+class GPTEngineerAgent(agent.Agent):
+    name: str = "gpt-engineer"
+    run_params: typing.Type[agent.ClientParams] = GPTEngineerAgentParams
+    splash: typing.Optional[
+        str
+        ] = """\
+
+                █████████          ██████  ██████  ████████ 
+             █████   ████         ██       ██   ██    ██    
+           ████   ████      ██    ██   ███ ██████     ██    
+          ███    ███     ██████   ██    ██ ██         ██    
+          ███     █████████ ███    ██████  ██         ██    
+           ███      ████   ████   
+         ████             ███     
+      ████    █████████████       ███████ ███    ██  ██████  
+   █████    ████                  ██      ████   ██ ██       
+  ███     ████                    █████   ██ ██  ██ ██   ███ 
+  ███   ███                       ██      ██  ██ ██ ██    ██ 
+   ██████                         ███████ ██   ████  ██████
+
+"""
+
+    async def run(self) -> typing.AsyncIterable[typing.List[file_diff.FileChange]]:
+        from dataclasses import dataclass, fields
+
+        def iter_fields(obj):
+            for field in fields(obj):
+                yield field.name, getattr(obj, field.name)
+        # typer.run(lambda: _main(**{k:v for k,v in iter_fields(self.run_params)}))
+        _main(**{k:v for k,v in iter_fields(self.run_params)})
+        assert RESULT is None
+        results = []
+
+        yield [file_diff.get_file_change(file_path, new_contents) for file_path, new_contents in RESULT.items()]
+
+if __name__ == "__main__":
+    agent.launcher(GPTEngineerAgent, GPTEngineerAgentParams)

--- a/rift-engine/rift/agents/gpt_eng.py
+++ b/rift-engine/rift/agents/gpt_eng.py
@@ -102,6 +102,8 @@ async def _main(
                 else:
                     SEEN.add(x[0])
         await asyncio.sleep(0.5)
+        # if step.__name__ == "gen_entrypoint":
+        #     await asyncio.sleep(3)
 
     # execute_steps_ = execute_steps()
 

--- a/rift-engine/rift/agents/gpt_eng.py
+++ b/rift-engine/rift/agents/gpt_eng.py
@@ -13,17 +13,6 @@ except ImportError:
 UPDATES_QUEUE = asyncio.Queue()
 SEEN = set()
 
-
-# def to_files(chat, workspace: gpt_engineer.db.DB):
-#     workspace["all_output.txt"] = chat
-#     files = gpt_engineer.chat_to_files.parse_chat(chat)
-
-#     for file_name, file_content in files:
-#         workspace[file_name] = file_content
-
-# # Assign a new to_files function that passes updates to the queue.
-# gpt_engineer.chat_to_files.to_files = to_files
-
 from gpt_engineer.ai import AI, fallback_model
 from gpt_engineer.collect import collect_learnings
 from gpt_engineer.db import DB, DBs, archive
@@ -93,8 +82,6 @@ async def _main(
         for step in steps:
             await asyncio.sleep(0.1)
             messages = await asyncio.get_running_loop().run_in_executor(pool, step, ai, dbs)
-            # messages = step(ai, dbs) # when `step.__name__` == `gen_entrypoint`, this proposes another diff for the `run.sh` shell script that you will also want to accept
-            # then all the files and `run.sh` should be SAVED before you accept the proposal to run the entrypoint
             await asyncio.sleep(0.1)
             dbs.logs[step.__name__] = json.dumps(messages)
             items = list(dbs.workspace.in_memory_dict.items())
@@ -106,29 +93,6 @@ async def _main(
                     else:
                         SEEN.add(x[0])
             await asyncio.sleep(0.5)
-
-        # TODO(pranav): uncomment this and increase the sleep duration as needed to make sure you can approve all the diffs before the entrypoint is generated --- this delays the appearance of the "run_entrypoint" step
-        # if step.__name__ == "gen_entrypoint":
-        #     await asyncio.sleep(3) # increase as needed
-
-        # steps:
-        # get the above flow working with the ugly ascii art
-        # fix the ascii art somehow (better fonts, etc)
-        # run it from top to bottom with the following script:
-        # contents of `prompt` should be
-        # write a reference implementation of order matching engine in Python
-        # during the clarification stage, specify that the order matching engine should run behind an HTTP server with an endpoint called `place_order` which accepts an `order` argument where an `order` is a JSON message of the shape `{order_type: Literal["market", "limit"], amount: float}` and which returns a boolean `{order_placed: boolean}`
-
-        # make sure that we run with gpt-4 for the camera ready
-
-    # execute_steps_ = execute_steps()
-
-    # if collect_consent():
-    #     collect_learnings(model, temperature, steps, dbs)
-
-    # dbs.logs["token_usage"] = ai.format_token_usage_log()
-    # return dbs.workspace
-
 
 @dataclass
 class GPTEngineerAgentParams(agent.ClientParams):

--- a/rift-engine/rift/agents/gpt_eng.py
+++ b/rift-engine/rift/agents/gpt_eng.py
@@ -106,6 +106,9 @@ class GPTEngineerAgentParams(agent.ClientParams):
 
 @dataclass
 class GPTEngineerAgent(agent.Agent):
+    """
+    Specify what you want it to build, the AI asks for clarification, and then builds it.
+    """
     name: str = "gpt-engineer"
     run_params: typing.Type[agent.ClientParams] = GPTEngineerAgentParams
     splash: typing.Optional[

--- a/rift-engine/rift/agents/gpt_eng.py
+++ b/rift-engine/rift/agents/gpt_eng.py
@@ -97,10 +97,10 @@ async def _main(
         if len([x for x in items if x[0] not in SEEN]) > 0:
             await UPDATES_QUEUE.put([x for x in items if x[0] not in SEEN])
             for x in items:
-                if hash(x) in SEEN:
+                if x[0] in SEEN:
                     pass
                 else:
-                    SEEN.add(hash(x))
+                    SEEN.add(x[0])
         await asyncio.sleep(0.5)
 
         # TODO(pranav): uncomment this and increase the sleep duration as needed to make sure you can approve all the diffs before the entrypoint is generated --- this delays the appearance of the "run_entrypoint" step

--- a/rift-engine/rift/agents/gpt_eng.py
+++ b/rift-engine/rift/agents/gpt_eng.py
@@ -89,7 +89,8 @@ async def _main(
 
     for step in steps:
         await asyncio.sleep(0.1)
-        messages = step(ai, dbs)
+        messages = step(ai, dbs) # when `step.__name__` == `gen_entrypoint`, this proposes another diff for the `run.sh` shell script that you will also want to accept
+        # then all the files and `run.sh` should be SAVED before you accept the proposal to run the entrypoint
         await asyncio.sleep(0.1)
         dbs.logs[step.__name__] = json.dumps(messages)
         
@@ -102,8 +103,20 @@ async def _main(
                 else:
                     SEEN.add(x[0])
         await asyncio.sleep(0.5)
+
+        # TODO(pranav): uncomment this and increase the sleep duration as needed to make sure you can approve all the diffs before the entrypoint is generated --- this delays the appearance of the "run_entrypoint" step
         # if step.__name__ == "gen_entrypoint":
-        #     await asyncio.sleep(3)
+        #     await asyncio.sleep(3) # increase as needed
+
+        # steps:
+        # get the above flow working with the ugly ascii art
+        # fix the ascii art somehow (better fonts, etc)
+        # run it from top to bottom with the following script:
+        # contents of `prompt` should be
+        # write a reference implementation of order matching engine in Python
+        # during the clarification stage, specify that the order matching engine should run behind an HTTP server with an endpoint called `place_order` which accepts an `order` argument where an `order` is a JSON message of the shape `{order_type: Literal["market", "limit"], amount: float}` and which returns a boolean `{order_placed: boolean}`
+
+        # make sure that we run with gpt-4 for the camera ready
 
     # execute_steps_ = execute_steps()
 

--- a/rift-engine/rift/agents/gpt_eng.py
+++ b/rift-engine/rift/agents/gpt_eng.py
@@ -30,6 +30,7 @@ def to_files(chat, workspace, queue: asyncio.Queue):
     files = parse_chat(chat)
     for file_name, file_content in files:
         workspace[file_name] = file_content
+        print("added to queue")
         queue.put_nowait(workspace)
 
 
@@ -143,12 +144,15 @@ class GPTEngineerAgent(agent.Agent):
                     for file_path, new_contents in workspace.items()]
         finally:
             # Cleanup: cancel the main_task if it is still running.
-            if not main_task.done():
-                main_task.cancel()
-                try:
-                    await main_task
-                except asyncio.CancelledError:
-                    pass
+            try:
+                if not main_task.done():
+                    main_task.cancel()
+                    try:
+                        await main_task
+                    except asyncio.CancelledError:
+                        pass
+            except: 
+                pass
 
 if __name__ == "__main__":
     agent.launcher(GPTEngineerAgent, GPTEngineerAgentParams)

--- a/rift-engine/rift/agents/smol.py
+++ b/rift-engine/rift/agents/smol.py
@@ -6,18 +6,16 @@ import logging
 import os
 import pickle as pkl
 from dataclasses import dataclass, field
-from typing import Any, AsyncIterable, ClassVar, Dict, List, Optional, Type, Literal
-import tqdm.asyncio
+from typing import Any, AsyncIterable, ClassVar, Dict, List, Literal, Optional, Type
 
-from rich.console import Console
-from rich.logging import RichHandler
-from rich.panel import Panel
-
-
-import rift.util.file_diff as file_diff
 import rift.lsp.types as lsp
 import rift.server.core as core
 import rift.server.lsp as server
+import rift.util.file_diff as file_diff
+import tqdm.asyncio
+from rich.console import Console
+from rich.logging import RichHandler
+from rich.panel import Panel
 from rift.lsp.types import InitializeParams
 from rift.rpc.io_transport import AsyncStreamTransport
 from rift.rpc.jsonrpc import RpcServer, rpc_method, rpc_request
@@ -30,10 +28,10 @@ import types
 
 import art
 import fire
+import smol_dev
 from rift.agents.cli_agent import Agent, ClientParams, launcher
 from rift.agents.util import ainput
 
-import smol_dev
 
 @dataclass
 class SmolAgentClientParams(ClientParams):
@@ -46,6 +44,7 @@ class SmolAgentClientParams(ClientParams):
     debug: bool - A flag to indicate whether the application is in debug mode. Default is False.
     model: Literal["gpt-3.5-turbo-0613", "gpt-4-0613"] - The model to be used. Default is "gpt-3.5-turbo-0613".
     """
+
     prompt_file: Optional[str] = None  # path to prompt file
     debug: bool = False
     model: Literal["gpt-3.5-turbo-0613", "gpt-4-0613"] = "gpt-3.5-turbo-0613"
@@ -62,6 +61,7 @@ class SmolAgent(Agent):
     run_params: Type[SmolAgentClientParams] - The parameters for running the agent. It uses the SmolAgentClientParams class.
     splash: Optional[str] - The splash screen for the agent. It is a string of ASCII art.
     """
+
     name: ClassVar[str] = "smol"
     run_params: Type[SmolAgentClientParams] = SmolAgentClientParams
     splash: Optional[
@@ -139,7 +139,9 @@ class SmolAgent(Agent):
         async def generate_code_for_filepath(file_path: str, position: int) -> file_diff.FileChange:
             stream_handler = lambda chunk: pbar.update(n=len(chunk))
             code_future = asyncio.ensure_future(
-                smol_dev.generate_code(prompt, plan, file_path, stream_handler=stream_handler, model=params.model)
+                smol_dev.generate_code(
+                    prompt, plan, file_path, stream_handler=stream_handler, model=params.model
+                )
             )
             with tqdm.asyncio.tqdm(position=position, unit=" chars", unit_scale=True) as pbar:
                 async with updater.lock:


### PR DESCRIPTION
This adds support for `gpt-engineer` (https://github.com/AntonOsika/gpt-engineer) using the Rift Agents API.

Addresses https://github.com/morph-labs/rift/issues/67.