### PR TITLE
Support remote lsps

### DIFF
--- a/editors/rift-vscode/README.md
+++ b/editors/rift-vscode/README.md
@@ -23,7 +23,7 @@ cd rift
 pip install -e ./rift-engine
 
 # launch the language server
-python -m rift.server.core --port 7797
+python -m rift.server.core --host 127.0.0.1 --port 7797
 ```
 
 This requires a working Python (>=3.9) installation.

--- a/editors/rift-vscode/package.json
+++ b/editors/rift-vscode/package.json
@@ -60,6 +60,16 @@
             "openai:gpt-4"
           ],
           "markdownDescription": "model to use for completions. (remember to set the OpenAI API key if using an openai:* model). You can also set your own (use the JSON settings editor), the format is `{type}:{name} [@ {path}]` where `type` is one of `gpt4all`, `openai`, or `hf` (for huggingface models), `name` is the name of the model, and `path` is an optional path to the downloaded model weights."
+        },
+        "rift.engineServer.host": {
+          "type": "string",
+          "default": "127.0.0.1",
+          "description": "Specifies the host that the Rift Engine is running on."
+        },
+        "rift.engineServer.port": {
+          "type": "integer",
+          "default": 7797,
+          "description": "Specifies the port number the Rift Engine is listening on."
         }
       }
     },

--- a/rift-engine/rift/__about__.py
+++ b/rift-engine/rift/__about__.py
@@ -1,4 +1,4 @@
 # SPDX-FileCopyrightText: 2023-present E.W.Ayers <edward.ayers@outlook.com>
 #
 # SPDX-License-Identifier: MIT
-__version__ = '0.0.6'
+__version__ = '0.0.7'


### PR DESCRIPTION
Adds support for running a Rift server on different computer raised in issue #13.

Server and VS Code extension updated to allow configurable host which allows setting of IP of a different computer.