### PR TITLE
Rift 2.0.1

### DIFF
--- a/editors/rift-vscode/package-lock.json
+++ b/editors/rift-vscode/package-lock.json
@@ -8,6 +8,7 @@
       "name": "rift-vscode",
       "version": "0.0.12",
       "dependencies": {
+        "@iarna/toml": "^2.2.5",
         "@tiptap/core": "^2.0.4",
         "@tiptap/extension-mention": "^2.0.4",
         "@tiptap/extension-placeholder": "^2.0.4",
@@ -640,6 +641,11 @@
       "resolved": "https://registry.npmjs.org/@humanwhocodes/object-schema/-/object-schema-1.2.1.tgz",
       "integrity": "sha512-ZnQMnLV4e7hDlUvw8H+U8ASL02SS2Gn6+9Ac3wGGLIe7+je2AeAOxPY+izIPJDfFDb7eDjev0Us8MO1iFRN8hA==",
       "dev": true
+    },
+    "node_modules/@iarna/toml": {
+      "version": "2.2.5",
+      "resolved": "https://registry.npmjs.org/@iarna/toml/-/toml-2.2.5.tgz",
+      "integrity": "sha512-trnsAYxU3xnS1gPHPyU961coFyLkh4gAD/0zQ5mymY4yOZ+CYvsPqUbOFSw0aDM4y0tV7tiFxL/1XfXPNC6IPg=="
     },
     "node_modules/@jridgewell/gen-mapping": {
       "version": "0.3.3",

--- a/editors/rift-vscode/package.json
+++ b/editors/rift-vscode/package.json
@@ -191,6 +191,7 @@
     "webpack-cli": "^5.1.4"
   },
   "dependencies": {
+    "@iarna/toml": "^2.2.5",
     "@tiptap/core": "^2.0.4",
     "@tiptap/extension-mention": "^2.0.4",
     "@tiptap/extension-placeholder": "^2.0.4",

--- a/rift-engine/pyproject.toml
+++ b/rift-engine/pyproject.toml
@@ -7,7 +7,7 @@ allow-direct-references = true
 
 [project]
 name = "pyrift"
-version = "2.0.0"
+version = "2.0.1"
 description = ''
 readme = "README.md"
 requires-python = ">=3.9"

--- a/rift-engine/rift/__about__.py
+++ b/rift-engine/rift/__about__.py
@@ -1,1 +1,6 @@
-__version__ = "0.0.7"
+import importlib.metadata
+
+__version__ = importlib.metadata.version('pyrift')
+
+if __name__ == "__main__":
+    print(__version__)

--- a/rift-engine/rift/agents/aider_agent.py
+++ b/rift-engine/rift/agents/aider_agent.py
@@ -78,7 +78,7 @@ class Aider(agent.ThirdPartyAgent):
     params_cls: ClassVar[Any] = AiderAgentParams
 
     @classmethod
-    async def create(cls, params: AiderAgentParams, server):
+    async def create(cls, params: AiderAgentParams, server: Any) -> agent.ThirdPartyAgent:
         """
         Class method to create an instance of the Aider class.
         :param params: Parameters for the Aider agent.
@@ -96,7 +96,9 @@ class Aider(agent.ThirdPartyAgent):
         )
         return obj
 
-    async def apply_file_changes(self, updates) -> lsp.ApplyWorkspaceEditResponse:
+    async def apply_file_changes(
+        self, updates: List[file_diff.FileChange]
+    ) -> lsp.ApplyWorkspaceEditResponse:
         """
         Apply file changes to the workspace.
         :param updates: The updates to be applied.
@@ -111,7 +113,7 @@ class Aider(agent.ThirdPartyAgent):
             )
         )
 
-    async def _run_chat_thread(self, response_stream):
+    async def _run_chat_thread(self, response_stream: str) -> None:
         """
         Run the chat thread.
         :param response_stream: The stream of responses from the chat.
@@ -311,7 +313,7 @@ class Aider(agent.ThirdPartyAgent):
 
         aider.io.InputOutput.tool_output = tool_output
 
-        def show_send_output_stream(self, completion, silent):
+        def show_send_output_stream(self, completion, silent=False):
             for chunk in completion:
                 if chunk.choices[0].finish_reason == "length":
                     raise ExhaustedContextWindow()
@@ -351,6 +353,7 @@ class Aider(agent.ThirdPartyAgent):
                 filename = filename.__fspath__()
             file_change = file_diff.get_file_change(path=filename, new_content=new_content)
             file_changes.append(file_change)
+            print(f"{file_changes=}")
 
         # This is called when aider wants to commit after writing all the files
         # This is where the user should accept/reject the changes


### PR DESCRIPTION
- makes Rift compatible with Aider v0.12.1
- adds rift server popup with option to auto-install / auto-update if the local Rift server is out of date
- use `importlib` to make the pyproject.toml's `project.version` the source of truth
- fixes support for `gpt4all` chat models