### PR TITLE
Type inference nicety: add imports from typing

### DIFF
--- a/rift-engine/rift/agents/add_missing_types.py
+++ b/rift-engine/rift/agents/add_missing_types.py
@@ -224,6 +224,7 @@ class MissingTypesAgent(agent.ThirdPartyAgent):
             filter_function_ids=filter_function_ids,
             language=language,
             replace_body=False,
+            update_imports=True,
         )
         return edits
 

--- a/rift-engine/rift/ir/IR.py
+++ b/rift-engine/rift/ir/IR.py
@@ -61,6 +61,7 @@ class Declaration(Statement):
 @dataclass
 class Import:
     names: List[str] # import foo, bar, baz
+    substring: Substring # the substring of the document that corresponds to this import
     module_name: Optional[str] = None # from module_name import ...
 
 
@@ -291,6 +292,12 @@ class File:
             return [symbol for symbol in self._symbol_table.values() if name_filter(symbol.name)]
         else:
             return [symbol for symbol in self._symbol_table.values() if symbol.name == name]
+
+    def search_module_import(self, module_name: str) -> Optional[Import]:
+        for import_ in self._imports:
+            if import_.module_name == module_name:
+                return import_
+        return None
 
     def add_symbol(self, symbol: SymbolInfo) -> None:
         self._symbol_table[symbol.get_qualified_id()] = symbol

--- a/rift-engine/rift/ir/python_typing.py
+++ b/rift-engine/rift/ir/python_typing.py
@@ -1,0 +1,94 @@
+
+def generate_typing_types_set():
+    # from PEP 484 – Type Hints: https://peps.python.org/pep-0484/
+        
+    # Fundamental Building Blocks
+    fundamental_building_blocks = {
+        'Any',
+        'Union',
+        'Callable',
+        'Tuple',
+        'TypeVar',
+        'Generic',
+        'Type'
+    }
+
+    # Generic Variants of Builtin Collections
+    generic_variants_builtin = {
+        'Dict',
+        'DefaultDict',
+        'List',
+        'Set',
+        'FrozenSet'
+    }
+
+    # Generic Variants of Container ABCs
+    generic_variants_container_abcs = {
+        'Awaitable',
+        'AsyncIterable',
+        'AsyncIterator',
+        'ByteString',
+        'Collection',
+        'Container',
+        'ContextManager',
+        'Coroutine',
+        'Generator',
+        'Hashable',
+        'ItemsView',
+        'Iterable',
+        'Iterator',
+        'KeysView',
+        'Mapping',
+        'MappingView',
+        'MutableMapping',
+        'MutableSequence',
+        'MutableSet',
+        'Sequence',
+        'AbstractSet',  # formerly Set
+        'Sized'
+    }
+
+    # One-off Types
+    one_off_types = {
+        'Reversible',
+        'SupportsAbs',
+        'SupportsComplex',
+        'SupportsFloat',
+        'SupportsInt',
+        'SupportsRound',
+        'SupportsBytes'
+    }
+
+    # Convenience Definitions
+    convenience_definitions = {
+        'Optional',
+        'Text',
+        'AnyStr',
+        'NamedTuple',
+        'NewType',
+    }
+
+    # I/O Related Types
+    io_related_types = {
+        'IO',
+        'BinaryIO',
+        'TextIO'
+    }
+
+    # Combine all sets into a single set
+    all_types = (
+        fundamental_building_blocks
+        | generic_variants_builtin
+        | generic_variants_container_abcs
+        | one_off_types
+        | convenience_definitions
+        | io_related_types
+    )
+
+    return all_types
+
+typing_set = generate_typing_types_set()
+
+# Add a function to check if a name is in the typing types set
+def is_typing_type(name: str) -> bool:
+    return name in typing_set

--- a/rift-engine/rift/ir/response_test.txt
+++ b/rift-engine/rift/ir/response_test.txt
@@ -53,6 +53,8 @@ int main() {
 
 New document3:
 ```
+from typing import List, Tuple
+
 def foo() -> None:
     print("Hello world!")
 
@@ -61,7 +63,7 @@ def get_num_tokens(content: str) -> int:
     return len(ENCODER.encode(content))
 
 @cache
-def get_num_tokens2(content: t1) -> t2:
+def get_num_tokens2(content: t1) -> List[t2]:
     return len(ENCODER.encode(content))
 
 def bar() -> None:

--- a/rift-engine/rift/ir/test_response.py
+++ b/rift-engine/rift/ir/test_response.py
@@ -103,6 +103,7 @@ class Test:
     code3 = (
         dedent(
             """
+        from typing import Tuple
         def foo() -> None:
             print("Hello world!")
 
@@ -132,7 +133,7 @@ class Test:
         ...
                        
         @cache
-        def get_num_tokens2(content: t1) -> t2:           
+        def get_num_tokens2(content: t1) -> List[t2]:           
             return some(imaginary(code))
                        
         def foo() -> string:
@@ -182,6 +183,7 @@ def test_response():
         filter_function_ids=filter_function_ids,
         language=language,
         replace_body=False,
+        update_imports=True,
     )
     new_document3 = document3.apply_edits(edits3)
     new_test_output += f"\n\nNew document3:\n```\n{new_document3}```"


### PR DESCRIPTION
Add dynamic import extension for type-inferred functions in Python

This commit enhances the type inference agent to identify the types from Python's "typing" module in function signatures. If these types are not already imported, the commit modifies the file's AST (Abstract Syntax Tree) to either extend an existing import from the "typing" module or add a new import statement.

For example, if the type inference agent modifies a function signature to include "List", this change will ensure that "List" is properly imported from Python's "typing" module.