### PR TITLE
Add support for Azure OpenAI, Palm, Claude, Cohere, Replicate, Sagemaker (100+LLMs) - using litellm

### DIFF
--- a/rift-engine/pyproject.toml
+++ b/rift-engine/pyproject.toml
@@ -32,6 +32,7 @@ dependencies = [
   "aider-chat @ git+https://github.com/morph-labs/aider",
   "smol_dev @ git+https://github.com/morph-labs/smol_dev",
   "mentat-ai @ git+https://www.github.com/morph-labs/mentat",  
+  "litellm" @ git+https://github.com/BerriAI/litellm/",
   "protobuf"
 ]
 

--- a/rift-engine/rift/llm/openai_client.py
+++ b/rift-engine/rift/llm/openai_client.py
@@ -40,6 +40,7 @@ from rift.llm.openai_types import (
     Message,
 )
 from rift.util.TextStream import TextStream
+from litellm import completion
 
 logger = logging.getLogger(__name__)
 
@@ -457,6 +458,8 @@ class OpenAIClient(BaseSettings, AbstractCodeCompletionProvider, AbstractChatCom
             raise ValueError("To use streaming please use the _post_streaming method")
         payload = params.dict(exclude_none=True)
         path = self._make_path(endpoint)
+
+
         async with self.session.post(path, params=self.url_query, json=payload) as resp:
             if not resp.ok:
                 await self.handle_error(resp)
@@ -491,20 +494,21 @@ class OpenAIClient(BaseSettings, AbstractCodeCompletionProvider, AbstractChatCom
             **kwargs,
         )
         if self.default_model:
+            # select any of the LiteLLM supported LLMs here
             params.model = self.default_model
-        output_type = ChatCompletionResponse
 
         if stream:
-            return self._post_streaming(
-                endpoint,
-                params=params,
-                input_type=input_type,
-                stream_data_type=ChatCompletionChunk,
+            return completion(
+                params,
+                stream=True
             )
         else:
-            return self._post_endpoint(
-                endpoint, params=params, input_type=input_type, output_type=output_type
+            response =  completion(
+                params,
+                stream=True
             )
+            for chunk in response:
+                yield chunk # text content found at chunk['choices'][0]['delta']
 
     async def run_chat(
         self,


### PR DESCRIPTION
This PR adds support for the above mentioned LLMs using LiteLLM https://github.com/BerriAI/litellm/ 
Example
```python
from litellm import completion

## set ENV variables
os.environ["OPENAI_API_KEY"] = "openai key"
os.environ["COHERE_API_KEY"] = "cohere key"

messages = [{ "content": "Hello, how are you?","role": "user"}]

# openai call
response = completion(model="gpt-3.5-turbo", messages=messages)

# cohere call
response = completion("command-nightly", messages)

# anthropic call
response = completion(model="claude-instant-1", messages=messages)
```