### PR TITLE
Clean up agents code

### DIFF
--- a/rift-engine/rift/agents/__init__.py
+++ b/rift-engine/rift/agents/__init__.py
@@ -2,10 +2,10 @@ from .abstract import *
 from .aider_agent import *
 from .code_edit import *
 from .curl_agent import *
+from .docstring_agent import *
 from .engineer import *
 from .mentat_agent import *
 from .registry import *
 from .rift_chat import *
 from .smol import *
 from .type_inference_agent import *
-from .docstring_agent import *

--- a/rift-engine/rift/agents/abstract.py
+++ b/rift-engine/rift/agents/abstract.py
@@ -54,9 +54,9 @@ AgentTaskId = str
 class AgentParams:
     agent_type: str
     agent_id: str
-    textDocument: Optional[lsp.TextDocumentIdentifier]
     selection: Optional[lsp.Selection]
     position: Optional[lsp.Position]
+    textDocument: Optional[lsp.TextDocumentIdentifier]
     workspaceFolderPath: Optional[str]
     visibleEditorMetadata: Optional[List[lsp.EditorMetadata]]
 

--- a/rift-engine/rift/agents/abstract.py
+++ b/rift-engine/rift/agents/abstract.py
@@ -6,13 +6,11 @@ from dataclasses import dataclass, field
 from enum import Enum
 from typing import Any, ClassVar, Dict, List, Optional, Type, Union
 
-from pydantic import BaseModel
-
 import rift.llm.openai_types as openai
 import rift.lsp.types as lsp
 from rift.agents.agenttask import AgentTask
 from rift.llm.openai_types import Message as ChatMessage
-from rift.lsp import LspServer as BaseLspServer
+from rift.lsp import LspServer
 from rift.util.TextStream import TextStream
 
 logger = logging.getLogger(__name__)
@@ -98,7 +96,7 @@ class Agent:
     """
 
     agent_type: ClassVar[str]
-    server: Optional[BaseLspServer] = None
+    server: Optional[LspServer] = None
     state: Optional[AgentState] = None
     agent_id: Optional[str] = None
     tasks: List[AgentTask] = field(default_factory=list)
@@ -114,7 +112,7 @@ class Agent:
         return f"<{self.agent_type}> {self.agent_id}"
 
     @classmethod
-    async def create(cls, params: AgentParams, server: BaseLspServer):
+    async def create(cls, params: AgentParams, server: LspServer) -> "Agent":
         """
         Factory function which is responsible for constructing the agent's state.
         """

--- a/rift-engine/rift/agents/aider_agent.py
+++ b/rift-engine/rift/agents/aider_agent.py
@@ -1,7 +1,21 @@
+import asyncio
 import logging
 import os
 import re
+import time
 from concurrent import futures
+from dataclasses import dataclass, field
+from pathlib import PurePath
+from typing import Any, ClassVar, List, Optional
+
+from rich.text import Text
+
+import rift.agents.abstract as agent
+import rift.agents.registry as registry
+import rift.llm.openai_types as openai
+import rift.lsp.types as lsp
+import rift.util.file_diff as file_diff
+from rift.util.TextStream import TextStream
 
 aider_available = False
 try:
@@ -26,22 +40,6 @@ except ImportError:
     )
 
 
-import asyncio
-import logging
-import time
-from dataclasses import dataclass, field
-from pathlib import PurePath
-from typing import Any, ClassVar, List, Optional
-
-from rich.text import Text
-
-import rift.agents.abstract as agent
-import rift.agents.registry as registry
-import rift.llm.openai_types as openai
-import rift.lsp.types as lsp
-import rift.util.file_diff as file_diff
-from rift.util.TextStream import TextStream
-
 logger = logging.getLogger(__name__)
 
 
@@ -51,20 +49,14 @@ class AiderRunResult(agent.AgentRunResult):
 
 
 @dataclass
-class AiderAgentParams(agent.AgentParams):
-    ...
-
-
-@dataclass
 class AiderAgentState(agent.AgentState):
     """
     A data class that holds the state of an Aider agent.
     It has the following attributes:
-    - params (AiderAgentParams) : The parameters associated with the Aider agent.
+    - params : The parameters associated with the agent.
     - messages (List[openai.Message]) : A list of messages communicated with the openai API during the agent's run.
     """
 
-    params: AiderAgentParams
     messages: list[openai.Message]
     response_lock: asyncio.Lock = field(default_factory=asyncio.Lock)
 
@@ -80,10 +72,9 @@ class AiderAgentState(agent.AgentState):
 @dataclass
 class Aider(agent.ThirdPartyAgent):
     agent_type: ClassVar[str] = "aider"
-    params_cls: ClassVar[Any] = AiderAgentParams
 
     @classmethod
-    async def create(cls, params: AiderAgentParams, server: Any) -> agent.ThirdPartyAgent:
+    async def create(cls, params: agent.AgentParams, server: Any) -> agent.ThirdPartyAgent:
         """
         Class method to create an instance of the Aider class.
         :param params: Parameters for the Aider agent.
@@ -177,7 +168,6 @@ class Aider(agent.ThirdPartyAgent):
                 )
 
                 def refactor_uri_match(resp) -> str:
-
                     dropped_symbols = False
 
                     def replacement(m: re.Match[str]):
@@ -188,7 +178,6 @@ class Aider(agent.ThirdPartyAgent):
                             uri, symbol = parsed_uri.split("#")[0], parsed_uri.split("#")[1]
                         else:
                             uri = parsed_uri
-                        
 
                         reference = IR.Reference.from_uri(uri)
                         file_path = reference.file_path
@@ -196,10 +185,18 @@ class Aider(agent.ThirdPartyAgent):
                             file_path, self.state.params.workspaceFolderPath
                         )
                         if not resp.startswith("/add"):
-                            return f"`{relative_path}`" if not dropped_symbols else f"{symbol} @ `{relative_path}`"
+                            return (
+                                f"`{relative_path}`"
+                                if not dropped_symbols
+                                else f"{symbol} @ `{relative_path}`"
+                            )
                         else:
-                            return f"{relative_path}" if not dropped_symbols else f"{symbol} @ {relative_path}"
-                    
+                            return (
+                                f"{relative_path}"
+                                if not dropped_symbols
+                                else f"{symbol} @ {relative_path}"
+                            )
+
                     # def process_path(path):
                     #     relative_path = os.path.relpath(path, self.state.params.workspaceFolderPath)
                     #     if not resp.startswith("/add"):  # /add does not like a quoted path
@@ -222,7 +219,7 @@ class Aider(agent.ThirdPartyAgent):
             result = t.result()
             return result
 
-        ##### PATCHES
+        # PATCHES
 
         def confirm_ask(self, question, default="y"):
             # print(f"[confirm_ask] question={question}")

--- a/rift-engine/rift/agents/aider_agent.py
+++ b/rift-engine/rift/agents/aider_agent.py
@@ -15,6 +15,7 @@ import rift.agents.registry as registry
 import rift.llm.openai_types as openai
 import rift.lsp.types as lsp
 import rift.util.file_diff as file_diff
+from rift.lsp import LspServer
 from rift.util.TextStream import TextStream
 
 aider_available = False
@@ -74,7 +75,7 @@ class Aider(agent.ThirdPartyAgent):
     agent_type: ClassVar[str] = "aider"
 
     @classmethod
-    async def create(cls, params: agent.AgentParams, server: Any) -> agent.ThirdPartyAgent:
+    async def create(cls, params: agent.AgentParams, server: LspServer) -> agent.ThirdPartyAgent:
         """
         Class method to create an instance of the Aider class.
         :param params: Parameters for the Aider agent.

--- a/rift-engine/rift/agents/code_edit.py
+++ b/rift-engine/rift/agents/code_edit.py
@@ -35,12 +35,6 @@ class CodeEditProgress(AgentProgress):
     ready: bool = False
 
 
-# dataclass for representing the parameters of the code completion agent
-@dataclass
-class CodeEditAgentParams(AgentParams):
-    ...
-
-
 # dataclass for representing the state of the code completion agent
 @dataclass
 class CodeEditAgentState(AgentState):
@@ -48,7 +42,6 @@ class CodeEditAgentState(AgentState):
     document: lsp.TextDocumentItem
     active_range: lsp.Range
     cursor: lsp.Position
-    params: CodeEditAgentParams
     selection: lsp.Selection
     messages: list[openai.Message]
     additive_ranges: RangeSet = field(default_factory=RangeSet)
@@ -66,10 +59,9 @@ class CodeEditAgentState(AgentState):
 class CodeEditAgent(Agent):
     state: CodeEditAgentState
     agent_type: ClassVar[str] = "code_edit"
-    params_cls: ClassVar[Any] = CodeEditAgentParams
 
     @classmethod
-    async def create(cls, params: CodeEditAgentParams, server: Any) -> Agent:
+    async def create(cls, params: AgentParams, server: Any) -> Agent:
         logger.info(f"{params=}")
         model = await server.ensure_code_edit_model()  # TODO: not right, fix
         state = CodeEditAgentState(

--- a/rift-engine/rift/agents/code_edit.py
+++ b/rift-engine/rift/agents/code_edit.py
@@ -10,6 +10,7 @@ import rift.lsp.types as lsp
 from rift.agents.abstract import AgentProgress  # AgentTask,
 from rift.agents.abstract import Agent, AgentParams, AgentRunResult, AgentState, RequestChatRequest
 from rift.llm.abstract import AbstractCodeEditProvider
+from rift.lsp.server import LspServer
 from rift.server.selection import RangeSet
 from rift.util.context import resolve_inline_uris
 from rift.util.TextStream import TextStream
@@ -61,7 +62,7 @@ class CodeEditAgent(Agent):
     agent_type: ClassVar[str] = "code_edit"
 
     @classmethod
-    async def create(cls, params: AgentParams, server: Any) -> Agent:
+    async def create(cls, params: AgentParams, server: LspServer) -> Agent:
         logger.info(f"{params=}")
         model = await server.ensure_code_edit_model()  # TODO: not right, fix
         state = CodeEditAgentState(

--- a/rift-engine/rift/agents/curl_agent.py
+++ b/rift-engine/rift/agents/curl_agent.py
@@ -16,14 +16,7 @@ from rift.lsp.types import TextDocumentIdentifier
 
 
 @dataclass
-class CurlAgentParams(AgentParams):
-    textDocument: TextDocumentIdentifier
-    instructionPrompt: Optional[str] = None
-
-
-@dataclass
 class CurlAgentState(AgentState):
-    params: CurlAgentParams
     messages: list[openai.Message]
 
 
@@ -36,7 +29,6 @@ class CurlAgent(Agent):
 
     state: Optional[CurlAgentState] = None
     agent_type: str = "curl_agent"
-    params_cls: ClassVar[Any] = CurlAgentParams
 
     async def run(self):
         # Send an initial update
@@ -65,9 +57,7 @@ class CurlAgent(Agent):
                     self.state.messages.append(openai.Message.assistant(response_text))
 
     @classmethod
-    async def create(cls, params: CurlAgentParams, server):
-        # Convert the parameters to a CurlAgentParams object
-
+    async def create(cls, params: AgentParams, server):
         # Create the initial state
         state = CurlAgentState(
             params=params,

--- a/rift-engine/rift/agents/curl_agent.py
+++ b/rift-engine/rift/agents/curl_agent.py
@@ -12,6 +12,7 @@ import aiohttp
 import rift.agents.registry as registry
 import rift.llm.openai_types as openai
 from rift.agents.abstract import Agent, AgentParams, AgentState, RequestChatRequest
+from rift.lsp.server import LspServer
 from rift.lsp.types import TextDocumentIdentifier
 
 
@@ -57,7 +58,7 @@ class CurlAgent(Agent):
                     self.state.messages.append(openai.Message.assistant(response_text))
 
     @classmethod
-    async def create(cls, params: AgentParams, server):
+    async def create(cls, params: AgentParams, server: LspServer) -> "CurlAgent":
         # Create the initial state
         state = CurlAgentState(
             params=params,

--- a/rift-engine/rift/agents/docstring_agent.py
+++ b/rift-engine/rift/agents/docstring_agent.py
@@ -202,7 +202,7 @@ class MissingDocstringAgent(agent.ThirdPartyAgent):
     debug: bool = Config.debug
 
     @classmethod
-    async def create(cls, params: agent.AgentParams, server: LspServer) -> Any:
+    async def create(cls, params: agent.AgentParams, server: LspServer) -> "MissingDocstringAgent":
         state = State(params=params, messages=[], response_lock=asyncio.Lock())
         obj: agent.ThirdPartyAgent = cls(state=state, agent_id=params.agent_id, server=server)
         return obj

--- a/rift-engine/rift/agents/docstring_agent.py
+++ b/rift-engine/rift/agents/docstring_agent.py
@@ -19,10 +19,10 @@ import rift.lsp.types as lsp
 import rift.util.file_diff as file_diff
 from rift.agents.agenttask import AgentTask
 from rift.ir.missing_docstrings import (
-    FunctionMissingDocstring,
     FileMissingDocstrings,
-    functions_missing_docstrings_in_file,
+    FunctionMissingDocstring,
     files_missing_docstrings_in_project,
+    functions_missing_docstrings_in_file,
 )
 from rift.ir.response import (
     Replace,
@@ -39,18 +39,12 @@ Prompt = List[Message]
 
 
 @dataclass
-class Params(agent.AgentParams):
-    ...
-
-
-@dataclass
 class Result(agent.AgentRunResult):
     ...
 
 
 @dataclass
 class State(agent.AgentState):
-    params: Params
     messages: List[openai_types.Message]
     response_lock: asyncio.Lock = field(default_factory=asyncio.Lock)
 
@@ -59,7 +53,8 @@ class Config:
     debug = False
     model = "gpt-3.5-turbo"  # ["gpt-3.5-turbo-0613", "gpt-3.5-turbo-16k"]
     temperature = 0.0
-    max_size_group_missing_docstrings = 10  # Max number of functions to process at once
+    # Max number of functions to process at once
+    max_size_group_missing_docstrings = 10
 
 
 class MissingDocStringPrompt:
@@ -204,11 +199,10 @@ class FileProcess:
 @dataclass
 class MissingDocstringAgent(agent.ThirdPartyAgent):
     agent_type: ClassVar[str] = "missing_docstring_agent"
-    params_cls: ClassVar[Any] = Params
     debug: bool = Config.debug
 
     @classmethod
-    async def create(cls, params: Any, server: LspServer) -> Any:
+    async def create(cls, params: agent.AgentParams, server: LspServer) -> Any:
         state = State(params=params, messages=[], response_lock=asyncio.Lock())
         obj: agent.ThirdPartyAgent = cls(state=state, agent_id=params.agent_id, server=server)
         return obj

--- a/rift-engine/rift/agents/engineer.py
+++ b/rift-engine/rift/agents/engineer.py
@@ -111,11 +111,6 @@ class EngineerRunResult(AgentRunResult):
 
 
 @dataclass
-class EngineerAgentParams(AgentParams):
-    instructionPrompt: Optional[str] = None
-
-
-@dataclass
 class EngineerProgress(
     AgentProgress
 ):  # reports what tasks are active and responsible for reporting new tasks
@@ -125,7 +120,6 @@ class EngineerProgress(
 
 @dataclass
 class EngineerAgentState(AgentState):
-    params: EngineerAgentParams
     messages: list[openai.Message]
     change_futures: Dict[str, Future] = field(default_factory=dict)
     _done: bool = False
@@ -144,7 +138,6 @@ class EngineerAgentState(AgentState):
 class EngineerAgent(ThirdPartyAgent):
     state: EngineerAgentState
     agent_type: ClassVar[str] = "engineer"
-    params_cls: ClassVar[Any] = EngineerAgentParams
 
     async def _main(
         self,
@@ -335,7 +328,7 @@ class EngineerAgent(ThirdPartyAgent):
             logger.info(f"[_run_chat_thread] caught exception={e}, exiting")
 
     @classmethod
-    async def create(cls, params: EngineerAgentParams, server: Any) -> ThirdPartyAgent:
+    async def create(cls, params: AgentParams, server: Any) -> ThirdPartyAgent:
         state = EngineerAgentState(
             params=params,
             messages=[openai.Message.assistant("What do you want to build?")],

--- a/rift-engine/rift/agents/engineer.py
+++ b/rift-engine/rift/agents/engineer.py
@@ -1,6 +1,7 @@
 from concurrent import futures
 
 import rift.agents.registry as registry
+from rift.lsp.server import LspServer
 
 try:
     import gpt_engineer
@@ -328,7 +329,7 @@ class EngineerAgent(ThirdPartyAgent):
             logger.info(f"[_run_chat_thread] caught exception={e}, exiting")
 
     @classmethod
-    async def create(cls, params: AgentParams, server: Any) -> ThirdPartyAgent:
+    async def create(cls, params: AgentParams, server: LspServer) -> ThirdPartyAgent:
         state = EngineerAgentState(
             params=params,
             messages=[openai.Message.assistant("What do you want to build?")],

--- a/rift-engine/rift/agents/mentat_agent.py
+++ b/rift-engine/rift/agents/mentat_agent.py
@@ -7,6 +7,8 @@ from concurrent import futures
 from dataclasses import dataclass, field
 from typing import ClassVar, List, Optional, Type
 
+from rift.lsp.server import LspServer
+
 logger = logging.getLogger(__name__)
 
 import mentat.app
@@ -53,7 +55,7 @@ class Mentat(agent.ThirdPartyAgent):
     state: Optional[MentatAgentState] = None
 
     @classmethod
-    async def create(cls, params: agent.AgentParams, server):
+    async def create(cls, params: agent.AgentParams, server: LspServer) -> "Mentat":
         """
         Create a new Mentat agent instance with the given parameters and server.
         :param params: The AgentParams containing agent configuration.

--- a/rift-engine/rift/agents/mentat_agent.py
+++ b/rift-engine/rift/agents/mentat_agent.py
@@ -26,13 +26,7 @@ from rift.util.TextStream import TextStream
 
 
 @dataclass
-class MentatAgentParams(agent.AgentParams):
-    paths: List[str] = field(default_factory=list)
-
-
-@dataclass
 class MentatAgentState(agent.AgentState):
-    params: MentatAgentParams
     messages: list[openai.Message]
     response_lock: asyncio.Lock = field(default_factory=asyncio.Lock)
     _response_buffer: str = ""
@@ -56,17 +50,16 @@ class MentatRunResult(agent.AgentRunResult):
 @dataclass
 class Mentat(agent.ThirdPartyAgent):
     agent_type: ClassVar[str] = "mentat"
-    run_params: Type[MentatAgentParams] = MentatAgentParams
     state: Optional[MentatAgentState] = None
 
     @classmethod
-    async def create(cls, params: MentatAgentParams, server):
+    async def create(cls, params: agent.AgentParams, server):
         """
         Create a new Mentat agent instance with the given parameters and server.
-        :param params: The MentatAgentParams containing agent configuration.
+        :param params: The AgentParams containing agent configuration.
         :param server: The server instance.
         :return: A new Mentat agent instance.
-        """        
+        """
         logger.info(f"{params=}")
         state = MentatAgentState(
             params=params,
@@ -155,7 +148,11 @@ class Mentat(agent.ThirdPartyAgent):
                         relative_path = os.path.relpath(
                             file_path, self.state.params.workspaceFolderPath
                         )
-                        return f"`{relative_path}`" if not dropped_symbols else f"{symbol} @ `{relative_path}`"
+                        return (
+                            f"`{relative_path}`"
+                            if not dropped_symbols
+                            else f"{symbol} @ `{relative_path}`"
+                        )
 
                     resp = re.sub(uri_pattern, replacement, resp)
                     return resp

--- a/rift-engine/rift/agents/reverso.py
+++ b/rift-engine/rift/agents/reverso.py
@@ -8,6 +8,7 @@ from typing import Any, ClassVar, Dict, Optional
 import rift.lsp.types as lsp
 from rift.agents.abstract import AgentProgress  # AgentTask,
 from rift.agents.abstract import Agent, AgentParams, AgentRunResult, AgentState, agent
+from rift.lsp.server import LspServer
 from rift.server.selection import RangeSet
 from rift.util.TextStream import TextStream
 
@@ -54,7 +55,7 @@ class ReversoAgent(Agent):
     agent_type: ClassVar[str] = "reverso"
 
     @classmethod
-    async def create(cls, params: Dict[Any, Any], server):
+    async def create(cls, params: Dict[Any, Any], server: LspServer) -> "ReversoAgent":
         state = ReversoAgentState(
             document=server.documents[params.textDocument.uri],
             active_range=lsp.Range(params.selection.start, params.selection.end),

--- a/rift-engine/rift/agents/reverso.py
+++ b/rift-engine/rift/agents/reverso.py
@@ -31,19 +31,12 @@ class ReversoProgress(AgentProgress):
     negative_ranges: Optional[RangeSet] = None
 
 
-# dataclass for representing the parameters of the code completion agent
-@dataclass
-class ReversoAgentParams(AgentParams):
-    ...
-
-
 # dataclass for representing the state of the code completion agent
 @dataclass
 class ReversoAgentState(AgentState):
     document: lsp.TextDocumentItem
     active_range: lsp.Range
     cursor: lsp.Position
-    params: ReversoAgentParams
     selection: lsp.Selection
     additive_ranges: RangeSet = field(default_factory=RangeSet)
     negative_ranges: RangeSet = field(default_factory=RangeSet)

--- a/rift-engine/rift/agents/rift_chat.py
+++ b/rift-engine/rift/agents/rift_chat.py
@@ -23,11 +23,6 @@ class ChatRunResult(AgentRunResult):
 
 
 @dataclass
-class RiftChatAgentParams(AgentParams):
-    ...
-
-
-@dataclass
 class ChatProgress(
     AgentProgress
 ):  # reports what tasks are active and responsible for reporting new tasks
@@ -40,7 +35,6 @@ class RiftChatAgentState(AgentState):
     model: AbstractChatCompletionProvider
     messages: list[openai.Message]
     document: lsp.TextDocumentItem
-    params: RiftChatAgentParams
 
 
 @registry.agent(
@@ -51,7 +45,6 @@ class RiftChatAgentState(AgentState):
 class RiftChatAgent(Agent):
     state: Optional[RiftChatAgentState] = None
     agent_type: ClassVar[str] = "rift_chat"
-    params_cls: ClassVar[Any] = RiftChatAgentParams
 
     @classmethod
     async def create(cls, params: AgentParams, server: BaseLspServer):

--- a/rift-engine/rift/agents/rift_chat.py
+++ b/rift-engine/rift/agents/rift_chat.py
@@ -11,7 +11,7 @@ from rift.agents.abstract import AgentProgress  # AgentTask,
 from rift.agents.abstract import Agent, AgentParams, AgentRunResult, AgentState, RequestChatRequest
 from rift.agents.agenttask import AgentTask
 from rift.llm.abstract import AbstractChatCompletionProvider
-from rift.lsp import LspServer as BaseLspServer
+from rift.lsp import LspServer
 from rift.util.context import resolve_inline_uris
 
 logger = logging.getLogger(__name__)
@@ -47,7 +47,7 @@ class RiftChatAgent(Agent):
     agent_type: ClassVar[str] = "rift_chat"
 
     @classmethod
-    async def create(cls, params: AgentParams, server: BaseLspServer):
+    async def create(cls, params: AgentParams, server: LspServer) -> "RiftChatAgent":
         # logger.info(f"RiftChatAgent.create {params=}")
         model = await server.ensure_chat_model()
         if params.textDocument is None:

--- a/rift-engine/rift/agents/sample_agent.py
+++ b/rift-engine/rift/agents/sample_agent.py
@@ -8,6 +8,7 @@ from typing import Any, ClassVar, Optional
 
 import rift.llm.openai_types as openai
 from rift.agents.abstract import Agent, AgentParams, AgentState, RequestChatRequest
+from rift.lsp.server import LspServer
 from rift.lsp.types import TextDocumentIdentifier
 
 logger = logging.getLogger(__name__)
@@ -88,7 +89,7 @@ class SampleAgent(Agent):
             logger.info(f"[_run_chat_thread] caught exception={e}, exiting")
 
     @classmethod
-    async def create(cls, params: AgentParams, server):
+    async def create(cls, params: AgentParams, server: LspServer) -> "SampleAgent":
         # Convert the parameters to a SampleAgentParams object
 
         # Create the initial state

--- a/rift-engine/rift/agents/sample_agent.py
+++ b/rift-engine/rift/agents/sample_agent.py
@@ -14,14 +14,7 @@ logger = logging.getLogger(__name__)
 
 
 @dataclass
-class SampleAgentParams(AgentParams):
-    textDocument: TextDocumentIdentifier
-    instructionPrompt: Optional[str] = None
-
-
-@dataclass
 class SampleAgentState(AgentState):
-    params: SampleAgentParams
     messages: list[openai.Message]
 
 
@@ -41,7 +34,6 @@ class SampleAgent(Agent):
 
     state: Optional[SampleAgentState] = None
     agent_type: str = "sample_agent"
-    params_cls: ClassVar[Any] = SampleAgentParams
     response_lock: asyncio.Lock = field(default_factory=asyncio.Lock)
     _response_buffer: str = ""
 
@@ -96,7 +88,7 @@ class SampleAgent(Agent):
             logger.info(f"[_run_chat_thread] caught exception={e}, exiting")
 
     @classmethod
-    async def create(cls, params: SampleAgentParams, server):
+    async def create(cls, params: AgentParams, server):
         # Convert the parameters to a SampleAgentParams object
 
         # Create the initial state

--- a/rift-engine/rift/agents/smol.py
+++ b/rift-engine/rift/agents/smol.py
@@ -60,16 +60,9 @@ class SmolProgress(AgentProgress):
     ready: bool = False
 
 
-# dataclass for representing the parameters of the code completion agent
-@dataclass
-class SmolAgentParams(AgentParams):
-    instructionPrompt: Optional[str] = None
-
-
 # dataclass for representing the state of the code completion agent
 @dataclass
 class SmolAgentState(AgentState):
-    params: SmolAgentParams
     _done: bool = False
     messages: List[openai.Message] = field(default_factory=list)
     response_lock: asyncio.Lock = field(default_factory=asyncio.Lock)
@@ -88,10 +81,9 @@ class SmolAgentState(AgentState):
 class SmolAgent(ThirdPartyAgent):
     state: SmolAgentState
     agent_type: ClassVar[str] = "smol_dev"
-    params_cls: ClassVar[Any] = SmolAgentParams
 
     @classmethod
-    async def create(cls, params: SmolAgentParams, server: Any) -> ThirdPartyAgent:
+    async def create(cls, params: AgentParams, server: Any) -> ThirdPartyAgent:
         state = SmolAgentState(
             params=params,
             _done=False,

--- a/rift-engine/rift/agents/smol.py
+++ b/rift-engine/rift/agents/smol.py
@@ -1,6 +1,7 @@
 from concurrent import futures
 
 import rift.agents.registry as registry
+from rift.lsp.server import LspServer
 from rift.util.TextStream import TextStream
 
 try:
@@ -83,7 +84,7 @@ class SmolAgent(ThirdPartyAgent):
     agent_type: ClassVar[str] = "smol_dev"
 
     @classmethod
-    async def create(cls, params: AgentParams, server: Any) -> ThirdPartyAgent:
+    async def create(cls, params: AgentParams, server: LspServer) -> ThirdPartyAgent:
         state = SmolAgentState(
             params=params,
             _done=False,

--- a/rift-engine/rift/agents/type_inference_agent.py
+++ b/rift-engine/rift/agents/type_inference_agent.py
@@ -183,7 +183,7 @@ class TypeInferenceAgent(agent.ThirdPartyAgent):
     debug = Config.debug
 
     @classmethod
-    async def create(cls, params: Any, server: LspServer) -> Any:
+    async def create(cls, params: Any, server: LspServer) -> "TypeInferenceAgent":
         state = State(
             params=params,
             messages=[],

--- a/rift-engine/rift/agents/type_inference_agent.py
+++ b/rift-engine/rift/agents/type_inference_agent.py
@@ -35,18 +35,12 @@ from rift.util.TextStream import TextStream
 
 
 @dataclass
-class Params(agent.AgentParams):
-    ...
-
-
-@dataclass
 class Result(agent.AgentRunResult):
     ...
 
 
 @dataclass
 class State(agent.AgentState):
-    params: Params
     messages: list[openai_types.Message]
     response_lock: asyncio.Lock = field(default_factory=asyncio.Lock)
 
@@ -185,7 +179,6 @@ def get_num_missing_in_code(code: IR.Code, language: IR.Language) -> int:
 @dataclass
 class TypeInferenceAgent(agent.ThirdPartyAgent):
     agent_type: ClassVar[str] = "missing_types"
-    params_cls: ClassVar[Any] = Params
 
     debug = Config.debug
 
@@ -365,7 +358,8 @@ class TypeInferenceAgent(agent.ThirdPartyAgent):
         text_document = self.get_state().params.textDocument
         if text_document is not None:
             parsed = urlparse(text_document.uri)
-            current_file_uri = url2pathname(unquote(parsed.path)) # Work around bug: https://github.com/scikit-hep/uproot5/issues/325#issue-850683423
+            # Work around bug: https://github.com/scikit-hep/uproot5/issues/325#issue-850683423
+            current_file_uri = url2pathname(unquote(parsed.path))
         else:
             raise Exception("Missing textDocument")
 

--- a/rift-engine/rift/ir/completions.py
+++ b/rift-engine/rift/ir/completions.py
@@ -29,10 +29,8 @@ def get_symbol_completions_raw(project: IR.Project) -> List[Dict[str, Symbol]]:
         symbols: List[Symbol] = []
         for symbol in file_ir.search_symbol(lambda _: True):
             if isinstance(symbol.symbol_kind, IR.MetaSymbolKind):
-                continue # don't emit completions for statements inside bodies
-            symbol = Symbol(
-                symbol.name, symbol.scope, symbol.kind(), symbol.range
-            )
+                continue  # don't emit completions for statements inside bodies
+            symbol = Symbol(symbol.name, symbol.scope, symbol.kind(), symbol.range)
             symbols.append(symbol)
         file = File(file_ir.path, symbols)
         files.append(file)

--- a/rift-engine/rift/ir/index.py
+++ b/rift-engine/rift/ir/index.py
@@ -3,16 +3,18 @@
 # python -m spacy download en_core_web_md
 
 import asyncio
-from dataclasses import dataclass
 import math
-import openai
 import os
 import pickle
 import time
+from dataclasses import dataclass
+from typing import Awaitable, Callable, Dict, List, Optional, Tuple
+
 import numpy as np
 import numpy.typing as npt
+import openai
 import tiktoken
-from typing import Awaitable, Callable, Dict, List, Optional, Tuple
+
 import rift.ir.IR as IR
 from rift.ir.parser import parse_files_in_paths
 

--- a/rift-engine/rift/ir/parser.py
+++ b/rift-engine/rift/ir/parser.py
@@ -41,7 +41,10 @@ def parse_code_block(
 
 
 def parse_path(
-    path: str, project: IR.Project, filter_file: Optional[Callable[[str], bool]] = None, metasymbols: bool = False
+    path: str,
+    project: IR.Project,
+    filter_file: Optional[Callable[[str], bool]] = None,
+    metasymbols: bool = False,
 ) -> None:
     """
     Parses a single file and adds it to the provided Project instance.

--- a/rift-engine/rift/ir/parser_core.py
+++ b/rift-engine/rift/ir/parser_core.py
@@ -1,5 +1,5 @@
-from dataclasses import dataclass, field
 import logging
+from dataclasses import dataclass, field
 from typing import Dict, List, Optional, Tuple
 
 from tree_sitter import Node
@@ -14,18 +14,18 @@ from rift.ir.IR import (
     DefKind,
     Expression,
     ExpressionKind,
-    GuardKind,
-    Item,
+    Field,
     File,
     FunctionKind,
+    GuardKind,
     IfKind,
     Import,
     InterfaceKind,
+    Item,
     Language,
     ModuleKind,
     NamespaceKind,
     Parameter,
-    Field,
     Scope,
     SectionKind,
     StructureKind,

--- a/rift-engine/rift/ir/response.py
+++ b/rift-engine/rift/ir/response.py
@@ -1,12 +1,12 @@
-from enum import Enum
+import logging
 import re
 import textwrap
+from enum import Enum
 from typing import List, Optional, Set, Tuple
 
 import rift.ir.IR as IR
 import rift.ir.parser as parser
 import rift.ir.python_typing as python_typing
-import logging
 
 logger = logging.getLogger(__name__)
 
@@ -80,9 +80,7 @@ def replace_functions_in_document(
     """
     Replaces functions in the document with corresponding functions from parsed blocks.
     """
-    function_declarations_in_document: List[
-        IR.Symbol
-    ] = ir_doc.get_function_declarations()
+    function_declarations_in_document: List[IR.Symbol] = ir_doc.get_function_declarations()
 
     code_edits: List[IR.CodeEdit] = []
     updated_functions: List[IR.Symbol] = []

--- a/rift-engine/rift/ir/test_completions.py
+++ b/rift-engine/rift/ir/test_completions.py
@@ -1,7 +1,6 @@
 import difflib
 import os
 
-
 import rift.ir.completions as completions
 import rift.ir.IR as IR
 import rift.ir.parser as parser

--- a/rift-engine/rift/ir/test_response.py
+++ b/rift-engine/rift/ir/test_response.py
@@ -3,9 +3,9 @@ import os
 from textwrap import dedent
 
 import rift.ir.IR as IR
-from rift.ir.missing_docstrings import functions_missing_docstrings_in_file
 import rift.ir.parser as parser
 import rift.ir.response as response
+from rift.ir.missing_docstrings import functions_missing_docstrings_in_file
 from rift.ir.missing_types import functions_missing_types_in_file
 
 

--- a/rift-engine/rift/server/lsp.py
+++ b/rift-engine/rift/server/lsp.py
@@ -11,7 +11,7 @@ from typing import Any, Dict, List, Optional, Tuple
 import pydantic
 
 import rift.lsp.types as lsp
-from rift.agents import AGENT_REGISTRY, Agent, AgentParams, AgentRegistryResult
+from rift.agents import AGENT_REGISTRY, Agent, AgentRegistryResult
 from rift.ir.completions import get_symbol_completions_raw
 from rift.ir.parser import parse_files_in_paths
 from rift.llm.abstract import AbstractChatCompletionProvider, AbstractCodeCompletionProvider


### PR DESCRIPTION
The agent params are sent from the client, and are the same for all agents. So there's no customisation in practice.

Remove redundant class member that were set per agent but were already inherited from the abstract agent class.