### PR TITLE
Agents cleanup: move messages to abstract state.

### DIFF
--- a/rift-engine/rift/agents/abstract.py
+++ b/rift-engine/rift/agents/abstract.py
@@ -81,6 +81,7 @@ class AgentState(ABC):
     """
 
     params: AgentParams
+    messages: list[openai.Message]
 
 
 @dataclass

--- a/rift-engine/rift/agents/aider_agent.py
+++ b/rift-engine/rift/agents/aider_agent.py
@@ -55,10 +55,8 @@ class AiderAgentState(agent.AgentState):
     A data class that holds the state of an Aider agent.
     It has the following attributes:
     - params : The parameters associated with the agent.
-    - messages (List[openai.Message]) : A list of messages communicated with the openai API during the agent's run.
     """
 
-    messages: list[openai.Message]
     response_lock: asyncio.Lock = field(default_factory=asyncio.Lock)
 
 

--- a/rift-engine/rift/agents/code_edit.py
+++ b/rift-engine/rift/agents/code_edit.py
@@ -44,7 +44,6 @@ class CodeEditAgentState(AgentState):
     active_range: lsp.Range
     cursor: lsp.Position
     selection: lsp.Selection
-    messages: list[openai.Message]
     additive_ranges: RangeSet = field(default_factory=RangeSet)
     negative_ranges: RangeSet = field(default_factory=RangeSet)
     change_futures: Dict[str, Future] = field(default_factory=dict)

--- a/rift-engine/rift/agents/curl_agent.py
+++ b/rift-engine/rift/agents/curl_agent.py
@@ -18,7 +18,7 @@ from rift.lsp.types import TextDocumentIdentifier
 
 @dataclass
 class CurlAgentState(AgentState):
-    messages: list[openai.Message]
+    pass
 
 
 @dataclass

--- a/rift-engine/rift/agents/docstring_agent.py
+++ b/rift-engine/rift/agents/docstring_agent.py
@@ -45,7 +45,6 @@ class Result(agent.AgentRunResult):
 
 @dataclass
 class State(agent.AgentState):
-    messages: List[openai_types.Message]
     response_lock: asyncio.Lock = field(default_factory=asyncio.Lock)
 
 

--- a/rift-engine/rift/agents/engineer.py
+++ b/rift-engine/rift/agents/engineer.py
@@ -121,7 +121,6 @@ class EngineerProgress(
 
 @dataclass
 class EngineerAgentState(AgentState):
-    messages: list[openai.Message]
     change_futures: Dict[str, Future] = field(default_factory=dict)
     _done: bool = False
 

--- a/rift-engine/rift/agents/mentat_agent.py
+++ b/rift-engine/rift/agents/mentat_agent.py
@@ -29,7 +29,6 @@ from rift.util.TextStream import TextStream
 
 @dataclass
 class MentatAgentState(agent.AgentState):
-    messages: list[openai.Message]
     response_lock: asyncio.Lock = field(default_factory=asyncio.Lock)
     _response_buffer: str = ""
 

--- a/rift-engine/rift/agents/rift_chat.py
+++ b/rift-engine/rift/agents/rift_chat.py
@@ -33,7 +33,6 @@ class ChatProgress(
 @dataclass
 class RiftChatAgentState(AgentState):
     model: AbstractChatCompletionProvider
-    messages: list[openai.Message]
     document: lsp.TextDocumentItem
 
 

--- a/rift-engine/rift/agents/sample_agent.py
+++ b/rift-engine/rift/agents/sample_agent.py
@@ -16,7 +16,7 @@ logger = logging.getLogger(__name__)
 
 @dataclass
 class SampleAgentState(AgentState):
-    messages: list[openai.Message]
+    pass
 
 
 """uncomment this to register the agent and access it from the Rift extension"""

--- a/rift-engine/rift/agents/smol.py
+++ b/rift-engine/rift/agents/smol.py
@@ -65,7 +65,6 @@ class SmolProgress(AgentProgress):
 @dataclass
 class SmolAgentState(AgentState):
     _done: bool = False
-    messages: List[openai.Message] = field(default_factory=list)
     response_lock: asyncio.Lock = field(default_factory=asyncio.Lock)
 
 

--- a/rift-engine/rift/agents/type_inference_agent.py
+++ b/rift-engine/rift/agents/type_inference_agent.py
@@ -41,7 +41,6 @@ class Result(agent.AgentRunResult):
 
 @dataclass
 class State(agent.AgentState):
-    messages: list[openai_types.Message]
     response_lock: asyncio.Lock = field(default_factory=asyncio.Lock)
 
 


### PR DESCRIPTION
All agents use messages in the state. This avoids repeating it in every agent.