### PR TITLE
Test index with aider

### DIFF
--- a/rift-engine/rift/ir/index.py
+++ b/rift-engine/rift/ir/index.py
@@ -240,6 +240,18 @@ class Index:
     version: str = version
 
     def search(self, query: Query) -> List[Tuple[PathWithId, float, IR.Symbol]]:
+        """
+        Searches the index for symbols that match the given query.
+
+        Args:
+            query: A Query object representing the search query.
+
+        Returns:
+            A list of tuples, where each tuple contains a PathWithId object representing the path and ID of the symbol,
+            a float representing the similarity score between the symbol and the query, and an IR.Symbol object representing
+            the symbol itself.
+
+        """
         scores: List[Tuple[PathWithId, float, IR.Symbol]] = [
             (path_with_id, e.similarity(query=query), e.symbol)
             for path_with_id, e in self.embeddings.items()
@@ -431,9 +443,7 @@ async def test_index() -> None:
     this_dir = os.path.dirname(__file__)
     project_root = __file__  # this file only
 
-    # project_root = os.path.dirname(
-    #     os.path.dirname(os.path.dirname(this_dir))
-    # )  # the whole rift project
+    project_root = os.path.dirname((os.path.dirname(this_dir)))  # the whole rift project
 
     openai = True
 
@@ -449,7 +459,7 @@ async def test_index() -> None:
         print("Creating index...")
         start = time.time()
         debug = True
-        index = await Index.create(project=project, max_tokens=100)
+        index = await Index.create(project=project)
 
         print(f"Created index in {time.time() - start:.2f} seconds")
         print(f"Saving index to file... {index_file}")
@@ -492,11 +502,8 @@ async def test_index() -> None:
 
     test_search(
         Text(
-            "Warning: symbol '{symbol.get_qualified_id()}' is too long ({len(symbol.get_substring().decode())} > {max_len}"
+            "Change the function that searches the index for symbols to return an object of a newly created class instead of a list of tuples."
         ),
-        # ["Function", "Class"],
-        ["Function", "Expression", "If", "Call", "Guard", "Body"],
-        num_results=10,
     )
     # test_search(And([Text("load")]), ["File"])
     # test_search(And([Text("load"), Not(in_query), Not(in_class)]), ["Function", "File"])

--- a/rift-engine/rift/ir/index.py
+++ b/rift-engine/rift/ir/index.py
@@ -239,9 +239,9 @@ class Index:
     project: IR.Project
     version: str = version
 
-    def search(self, query: Query) -> List[Tuple[PathWithId, float, IR.Range]]:
-        scores: List[Tuple[PathWithId, float, IR.Range]] = [
-            (path_with_id, e.similarity(query=query), e.symbol.range)
+    def search(self, query: Query) -> List[Tuple[PathWithId, float, IR.Symbol]]:
+        scores: List[Tuple[PathWithId, float, IR.Symbol]] = [
+            (path_with_id, e.similarity(query=query), e.symbol)
             for path_with_id, e in self.embeddings.items()
             if e.symbol.symbol_kind.name() in query.kinds
         ]
@@ -462,14 +462,16 @@ async def test_index() -> None:
     ) -> None:
         start = time.time()
         query = Query(node, num_results=num_results, kinds=kinds)  #  ["Class", "File"]
-        scores = index.search(query)
+        scores: List[Tuple[PathWithId, float, IR.Symbol]] = index.search(query)
         print("\nSemantic Search Results:")
         # Determine the maximum width for each column
         max_file_width = max(len(file) for (file, _), _, _ in scores)
         max_id_width = max(len(id) for (_, id), _, _ in scores)
         # Print the aligned output
-        for (file, id), score, range in scores:
-            print(f"{score:.3f} {file:<{max_file_width + 1}} {id:<{max_id_width + 1}} {range}")
+        for (file, id), score, symbol in scores:
+            print(
+                f"{score:.3f} {file:<{max_file_width + 1}} {id:<{max_id_width + 1}} {symbol.range}"
+            )
         elapsed = time.time() - start
         print(f"\nSearched in {elapsed:.2f} seconds")
 


### PR DESCRIPTION
1 Build the index: `pytest -s rift/ir/test_parser.py`
2 Open vscode from the root of `rift` and test aider with command: "Change the function that searches the index for symbols to return an object of a newly created class instead of a list of tuples."