### PR TITLE
IR: refactor symbol and symbol kinds with renamings and computed properties.

### DIFF
--- a/rift-engine/rift/agents/docstring_agent.py
+++ b/rift-engine/rift/agents/docstring_agent.py
@@ -85,7 +85,7 @@ class MissingDocStringPrompt:
     ) -> IR.Code:
         bytes = b""
         for function in functions_missing_docstrings:
-            bytes += function.function_declaration.get_substring()
+            bytes += function.function_declaration.substring
             bytes += b"\n"
         return IR.Code(bytes)
 

--- a/rift-engine/rift/agents/docstring_agent.py
+++ b/rift-engine/rift/agents/docstring_agent.py
@@ -220,8 +220,7 @@ class MissingDocstringAgent(agent.ThirdPartyAgent):
         if self.debug:
             logger.info(f"code_blocks: \n{code_blocks}\n")
         filter_function_ids = [
-            function.function_declaration.get_qualified_id()
-            for function in functions_missing_docstrings
+            function.function_declaration.qualified_id for function in functions_missing_docstrings
         ]
         x = replace_functions_from_code_blocks(
             code_blocks=code_blocks,
@@ -439,7 +438,7 @@ class MissingDocstringAgent(agent.ThirdPartyAgent):
                 functions_missing_docstrings = [
                     function_missing_docstrings
                     for function_missing_docstrings in file_missing_docstrings.functions_missing_docstrings
-                    if function_missing_docstrings.function_declaration.get_qualified_id()
+                    if function_missing_docstrings.function_declaration.qualified_id
                     in symbols_per_file[full_path]
                 ]
                 if functions_missing_docstrings != []:

--- a/rift-engine/rift/agents/docstring_agent.py
+++ b/rift-engine/rift/agents/docstring_agent.py
@@ -65,7 +65,7 @@ class MissingDocStringPrompt:
         n = 0
         for function in functions_missing_docstrings:
             n += 1
-            missing_str += f"{n}. {function.function_declaration.name}\n"
+            missing_str += f"{n}. {function.function_declaration.id}\n"
 
         return dedent(
             f"""
@@ -267,7 +267,7 @@ class MissingDocstringAgent(agent.ThirdPartyAgent):
 
         response_stream._feed_task = asyncio.create_task(  # type: ignore
             self.add_task(  # type: ignore
-                f"Write doc strings for {'/'.join(function.function_declaration.name for function in functions_missing_docstrings)}",
+                f"Write doc strings for {'/'.join(function.function_declaration.id for function in functions_missing_docstrings)}",
                 feed_task,
             ).run()
         )
@@ -292,7 +292,7 @@ class MissingDocstringAgent(agent.ThirdPartyAgent):
             split = len(group) == Config.max_size_group_missing_docstrings
             # also split if a function with the same name is in the current group (e.g. from another class)
             for function2 in group:
-                if function.function_declaration.name == function2.function_declaration.name:
+                if function.function_declaration.id == function2.function_declaration.id:
                     split = True
                     break
             if split:
@@ -380,7 +380,7 @@ class MissingDocstringAgent(agent.ThirdPartyAgent):
         async def log_missing(file_missing_docstrings: FileMissingDocstrings):
             await info_update(f"File: {file_missing_docstrings.ir_name.path}")
             for function in file_missing_docstrings.functions_missing_docstrings:
-                logger.info(f"Missing: {function.function_declaration.name}")
+                logger.info(f"Missing: {function.function_declaration.id}")
 
         async def get_user_response() -> str:
             result = await self.request_chat(

--- a/rift-engine/rift/agents/type_inference_agent.py
+++ b/rift-engine/rift/agents/type_inference_agent.py
@@ -206,7 +206,7 @@ class TypeInferenceAgent(agent.ThirdPartyAgent):
         code_blocks = extract_blocks_from_response(response)
         if self.debug:
             logger.info(f"code_blocks:\n{code_blocks}\n")
-        filter_function_ids = [mt.function_declaration.get_qualified_id() for mt in missing_types]
+        filter_function_ids = [mt.function_declaration.qualified_id for mt in missing_types]
         return replace_functions_from_code_blocks(
             code_blocks=code_blocks,
             document=document,
@@ -408,7 +408,7 @@ class TypeInferenceAgent(agent.ThirdPartyAgent):
                 missing_types = [
                     mt
                     for mt in fmt.missing_types
-                    if mt.function_declaration.get_qualified_id() in symbols_per_file[full_path]
+                    if mt.function_declaration.qualified_id in symbols_per_file[full_path]
                 ]
                 if missing_types != []:
                     fmt.missing_types = missing_types

--- a/rift-engine/rift/agents/type_inference_agent.py
+++ b/rift-engine/rift/agents/type_inference_agent.py
@@ -81,7 +81,7 @@ class MissingTypePrompt:
     def code_for_missing_types(missing_types: List[MissingType]) -> IR.Code:
         bytes = b""
         for mt in missing_types:
-            bytes += mt.function_declaration.get_substring()
+            bytes += mt.function_declaration.substring
             bytes += b"\n"
         return IR.Code(bytes)
 

--- a/rift-engine/rift/agents/type_inference_agent.py
+++ b/rift-engine/rift/agents/type_inference_agent.py
@@ -242,7 +242,7 @@ class TypeInferenceAgent(agent.ThirdPartyAgent):
 
         response_stream._feed_task = asyncio.create_task(  # type: ignore
             self.add_task(  # type: ignore
-                f"Generate type annotations for {'/'.join(mt.function_declaration.name for mt in missing_types)}",
+                f"Generate type annotations for {'/'.join(mt.function_declaration.id for mt in missing_types)}",
                 feed_task,
             ).run()
         )
@@ -266,7 +266,7 @@ class TypeInferenceAgent(agent.ThirdPartyAgent):
 
             # also split if a function with the same name is in the current group (e.g. from another class)
             for mt2 in group:
-                if mt.function_declaration.name == mt2.function_declaration.name:
+                if mt.function_declaration.id == mt2.function_declaration.id:
                     do_split = True
                     break
 

--- a/rift-engine/rift/ir/IR.py
+++ b/rift-engine/rift/ir/IR.py
@@ -70,7 +70,7 @@ class Block(List["Symbol"]):
     pass
 
     def __str__(self) -> str:
-        return f"{[x.name for x in self]}"
+        return f"{[x.id for x in self]}"
 
     def __repr__(self) -> str:
         return self.__str__()
@@ -82,7 +82,7 @@ class Case:
     body: "Symbol"
 
     def __str__(self) -> str:
-        return f"Case({self.guard.name}, {self.body.name})"
+        return f"Case({self.guard.id}, {self.body.id})"
 
     def __repr__(self) -> str:
         return self.__str__()
@@ -368,10 +368,10 @@ class ForKind(MetaSymbolKind):
         return "For"
 
     def dump(self, lines: List[str]) -> None:
-        lines.append(f"   for {self.left} in {self.right}: {self.body.name}")
+        lines.append(f"   for {self.left} in {self.right}: {self.body.id}")
 
     def __str__(self) -> str:
-        return f"for {self.left} in {self.right}: {self.body.name}"
+        return f"for {self.left} in {self.right}: {self.body.id}"
 
     def __repr__(self) -> str:
         return self.__str__()
@@ -447,14 +447,14 @@ class IfKind(MetaSymbolKind):
         if self.elif_cases != []:
             lines.append(f"   elif_cases: {self.elif_cases}")
         if self.else_body:
-            lines.append(f"   else_body: {self.else_body.name}")
+            lines.append(f"   else_body: {self.else_body.id}")
 
     def __str__(self) -> str:
-        if_str = f"if {self.if_case.guard.name}: {self.if_case.body.name}"
+        if_str = f"if {self.if_case.guard.id}: {self.if_case.body.id}"
         elif_str = "".join(
-            [f" elif {case.guard.name}: {case.body.name}" for case in self.elif_cases]
+            [f" elif {case.guard.id}: {case.body.id}" for case in self.elif_cases]
         )
-        else_str = f" else: {self.else_body.name}" if self.else_body else ""
+        else_str = f" else: {self.else_body.id}" if self.else_body else ""
         return f"{if_str}{elif_str}{else_str}"
 
     def __repr__(self) -> str:
@@ -521,14 +521,14 @@ class SwitchKind(MetaSymbolKind):
         return "Switch"
 
     def dump(self, lines: List[str]) -> None:
-        lines.append(f"   expression: {self.expression.name}")
+        lines.append(f"   expression: {self.expression.id}")
         lines.append(f"   cases: {self.cases}")
         if self.default:
-            lines.append(f"   default: {self.default.name}")
+            lines.append(f"   default: {self.default.id}")
 
     def __str__(self) -> str:
-        default_str = f" default: {self.default.name}" if self.default else ""
-        return f" switch {self.expression.name}: {self.cases}{default_str}"
+        default_str = f" default: {self.default.id}" if self.default else ""
+        return f" switch {self.expression.id}: {self.cases}{default_str}"
 
     def __repr__(self) -> str:
         return self.__str__()
@@ -618,7 +618,7 @@ class Symbol:
     docstring_sub: Optional[Substring]
     exported: bool
     language: Language
-    name: str
+    id: str
     range: Range
     parent: Optional["Symbol"]
     scope: Scope
@@ -635,7 +635,7 @@ class Symbol:
         """
         Returns the qualified identifier of the IR node, which is the concatenation of its scope and name.
         """
-        return self.scope + self.name
+        return self.scope + self.id
 
     def get_substring_without_body(self) -> bytes:
         """
@@ -669,9 +669,9 @@ class Symbol:
         """
         signature = self.symbol_kind.signature()
         if signature is not None:
-            id = self.name + signature
+            id = self.id + signature
         else:
-            id = self.name
+            id = self.id
         lines.append(
             f"{self.kind()}: {id}\n   language: {self.language}\n   range: {self.range}\n   substring: {self.substring}"
         )
@@ -719,7 +719,7 @@ def create_file_symbol(code: Code, language: Language, path: str) -> Symbol:
         docstring_sub=None,
         exported=False,
         language=language,
-        name=path,
+        id=path,
         parent=None,
         range=range,
         scope="",
@@ -758,9 +758,9 @@ class File:
     def search_symbol(self, name: Union[str, Callable[[str], bool]]) -> List[Symbol]:
         if callable(name):
             name_filter = name
-            return [symbol for symbol in self._symbol_table.values() if name_filter(symbol.name)]
+            return [symbol for symbol in self._symbol_table.values() if name_filter(symbol.id)]
         else:
-            return [symbol for symbol in self._symbol_table.values() if symbol.name == name]
+            return [symbol for symbol in self._symbol_table.values() if symbol.id == name]
 
     def search_module_import(self, module_name: str) -> Optional[Import]:
         for import_ in self._imports:
@@ -798,7 +798,7 @@ class File:
                 decl_without_body = decl_without_body.replace("\n", "\n" + " " * indent)
                 lines.append(f"{' ' * indent}{decl_without_body}")
             else:
-                lines.append(f"{' ' * indent}{symbol.name} = `{symbol.symbol_kind}`")
+                lines.append(f"{' ' * indent}{symbol.id} = `{symbol.symbol_kind}`")
             for s in symbol.body:
                 dump_symbol(s, indent + 2)
 

--- a/rift-engine/rift/ir/IR.py
+++ b/rift-engine/rift/ir/IR.py
@@ -1,5 +1,5 @@
 import os
-from abc import ABC, abstractmethod
+from abc import ABC, abstractmethod, abstractproperty
 from dataclasses import dataclass, field
 from typing import Callable, Dict, List, Literal, Optional, Tuple, Union
 
@@ -226,7 +226,7 @@ class SymbolKind(ABC):
 
     symbol: "Symbol"
 
-    @abstractmethod
+    @abstractproperty
     def name(self) -> SymbolKindName:
         raise NotImplementedError
 
@@ -268,6 +268,7 @@ class BodyKind(MetaSymbolKind):
 
     block: Block
 
+    @property
     def name(self) -> SymbolKindName:
         return "Body"
 
@@ -290,6 +291,7 @@ class CallKind(MetaSymbolKind):
     function_name: str
     arguments: List[Expression]
 
+    @property
     def name(self) -> SymbolKindName:
         return "Call"
 
@@ -313,6 +315,7 @@ class ClassKind(SymbolKind):
 
     superclasses: Optional[str]
 
+    @property
     def name(self) -> SymbolKindName:
         return "Class"
 
@@ -327,6 +330,7 @@ class DefKind(SymbolKind):
     Represents a mathematical definition in Lean: https://leanprover.github.io/lean4/doc/definitions.html
     """
 
+    @property
     def name(self) -> SymbolKindName:
         return "Def"
 
@@ -341,6 +345,7 @@ class ExpressionKind(MetaSymbolKind):
 
     code: str
 
+    @property
     def name(self) -> SymbolKindName:
         return "Expression"
 
@@ -360,6 +365,7 @@ class FileKind(MetaSymbolKind):
     Represents a file in the IR.
     """
 
+    @property
     def name(self) -> SymbolKindName:
         return "File"
 
@@ -372,6 +378,7 @@ class ForKind(MetaSymbolKind):
     right: Expression
     body: "Symbol"
 
+    @property
     def name(self) -> SymbolKindName:
         return "For"
 
@@ -400,6 +407,7 @@ class FunctionKind(SymbolKind):
     is_async: bool = False
     return_type: Optional[Type] = None
 
+    @property
     def name(self) -> SymbolKindName:
         return "Function"
 
@@ -420,6 +428,7 @@ class GuardKind(MetaSymbolKind):
 
     condition: Expression
 
+    @property
     def name(self) -> SymbolKindName:
         return "Guard"
 
@@ -447,6 +456,7 @@ class IfKind(MetaSymbolKind):
     elif_cases: List[Case]
     else_body: Optional["Symbol"]
 
+    @property
     def name(self) -> SymbolKindName:
         return "If"
 
@@ -473,6 +483,7 @@ class InterfaceKind(SymbolKind):
     Represents a kind of symbol that defines an interface.
     """
 
+    @property
     def name(self) -> SymbolKindName:
         return "Interface"
 
@@ -483,6 +494,7 @@ class ModuleKind(SymbolKind):
     Represents a module in the IR.
     """
 
+    @property
     def name(self) -> SymbolKindName:
         return "Module"
 
@@ -493,6 +505,7 @@ class NamespaceKind(SymbolKind):
     Represents a namespace in the IR.
     """
 
+    @property
     def name(self) -> SymbolKindName:
         return "Namespace"
 
@@ -501,6 +514,7 @@ class NamespaceKind(SymbolKind):
 class SectionKind(SymbolKind):
     """Represents a Lean section: https://leanprover.github.io/lean4/doc/sections.html"""
 
+    @property
     def name(self) -> SymbolKindName:
         return "Section"
 
@@ -511,6 +525,7 @@ class StructureKind(SymbolKind):
     Represents a structure in Lean: https://lean-lang.org/lean4/doc/struct.html
     """
 
+    @property
     def name(self) -> SymbolKindName:
         return "Structure"
 
@@ -523,6 +538,7 @@ class SwitchKind(MetaSymbolKind):
     cases: List[Case]
     default: Optional["Symbol"]
 
+    @property
     def name(self) -> SymbolKindName:
         return "Switch"
 
@@ -546,6 +562,7 @@ class TheoremKind(SymbolKind):
     Represents a theorem in Lean: https://lean-lang.org/theorem_proving_in_lean4/title_page.html
     """
 
+    @property
     def name(self) -> SymbolKindName:
         return "Theorem"
 
@@ -558,6 +575,7 @@ class TypeDefinitionKind(SymbolKind):
 
     type: Optional[Type] = None
 
+    @property
     def name(self) -> SymbolKindName:
         return "TypeDefinition"
 
@@ -567,7 +585,7 @@ class TypeDefinitionKind(SymbolKind):
 
     def __str__(self) -> str:
         if self.type is None:
-            return f"{self.name()}"
+            return f"{self.name}"
         else:
             return f"{self.type}"
 
@@ -578,6 +596,7 @@ class UnknownKind(MetaSymbolKind):
     Represents an unknown symbol kind.
     """
 
+    @property
     def name(self) -> SymbolKindName:
         return "Unknown"
 
@@ -590,6 +609,7 @@ class ValueKind(SymbolKind):
 
     type: Optional[Type] = None
 
+    @property
     def name(self) -> SymbolKindName:
         return "Value"
 
@@ -683,7 +703,7 @@ class Symbol:
 
     @property
     def name(self) -> str:
-        return self.kind.name()
+        return self.kind.name
 
     def dump(self, lines: List[str]) -> None:
         """

--- a/rift-engine/rift/ir/IR.py
+++ b/rift-engine/rift/ir/IR.py
@@ -451,9 +451,7 @@ class IfKind(MetaSymbolKind):
 
     def __str__(self) -> str:
         if_str = f"if {self.if_case.guard.id}: {self.if_case.body.id}"
-        elif_str = "".join(
-            [f" elif {case.guard.id}: {case.body.id}" for case in self.elif_cases]
-        )
+        elif_str = "".join([f" elif {case.guard.id}: {case.body.id}" for case in self.elif_cases])
         else_str = f" else: {self.else_body.id}" if self.else_body else ""
         return f"{if_str}{elif_str}{else_str}"
 
@@ -623,7 +621,7 @@ class Symbol:
     parent: Optional["Symbol"]
     scope: Scope
     substring: Substring
-    symbol_kind: SymbolKind
+    kind: SymbolKind
     embedding: Optional[Vector] = None
 
     def get_substring(self) -> bytes:
@@ -667,7 +665,7 @@ class Symbol:
         Args:
             lines (List[str]): The list of strings to append the string representation to.
         """
-        signature = self.symbol_kind.signature()
+        signature = self.kind.signature()
         if signature is not None:
             id = self.id + signature
         else:
@@ -687,10 +685,10 @@ class Symbol:
             lines.append(f"   body: {self.body}")
         if self.parent:
             lines.append(f"   parent: {self.parent.get_qualified_id()}")
-        self.symbol_kind.dump(lines)
+        self.kind.dump(lines)
 
     def name(self) -> str:
-        return self.symbol_kind.name()
+        return self.kind.name()
 
 
 def create_file_symbol(code: Code, language: Language, path: str) -> Symbol:
@@ -711,7 +709,7 @@ def create_file_symbol(code: Code, language: Language, path: str) -> Symbol:
         last_char_in_line = end_byte - last_newline_pos - 1
     range = ((first_line, 0), (last_line, last_char_in_line))
 
-    dummy_kind : SymbolKind = None # type: ignore
+    dummy_kind: SymbolKind = None  # type: ignore
     symbol = Symbol(
         body=Block(),
         body_sub=body_sub,
@@ -724,9 +722,9 @@ def create_file_symbol(code: Code, language: Language, path: str) -> Symbol:
         range=range,
         scope="",
         substring=body_sub,
-        symbol_kind=dummy_kind,
+        kind=dummy_kind,
     )
-    symbol.symbol_kind = FileKind(symbol)
+    symbol.kind = FileKind(symbol)
     return symbol
 
 
@@ -780,29 +778,29 @@ class File:
         return [
             symbol
             for symbol in self._symbol_table.values()
-            if isinstance(symbol.symbol_kind, FunctionKind)
+            if isinstance(symbol.kind, FunctionKind)
         ]
 
     def dump_symbol_table(self, lines: List[str]) -> None:
         for _, symbol in self._symbol_table.items():
-            if not isinstance(symbol.symbol_kind, UnknownKind):
+            if not isinstance(symbol.kind, UnknownKind):
                 symbol.dump(lines)
 
     def dump_map(self, indent: int, lines: List[str]) -> None:
         def dump_symbol(symbol: Symbol, indent: int) -> None:
-            if isinstance(symbol.symbol_kind, UnknownKind):
+            if isinstance(symbol.kind, UnknownKind):
                 pass
-            elif not isinstance(symbol.symbol_kind, MetaSymbolKind):
+            elif not isinstance(symbol.kind, MetaSymbolKind):
                 decl_without_body = symbol.get_substring_without_body().decode().strip()
                 # indent the declaration
                 decl_without_body = decl_without_body.replace("\n", "\n" + " " * indent)
                 lines.append(f"{' ' * indent}{decl_without_body}")
             else:
-                lines.append(f"{' ' * indent}{symbol.id} = `{symbol.symbol_kind}`")
+                lines.append(f"{' ' * indent}{symbol.id} = `{symbol.kind}`")
             for s in symbol.body:
                 dump_symbol(s, indent + 2)
 
-        assert self.symbol and isinstance(self.symbol.symbol_kind, FileKind)
+        assert self.symbol and isinstance(self.symbol.kind, FileKind)
         for symbol in self.symbol.body:
             dump_symbol(symbol, indent)
 

--- a/rift-engine/rift/ir/IR.py
+++ b/rift-engine/rift/ir/IR.py
@@ -229,6 +229,10 @@ class SymbolKind(ABC):
     @abstractproperty
     def name(self) -> SymbolKindName:
         raise NotImplementedError
+    
+    @property
+    def parent(self) -> Optional["Symbol"]:
+        return self.symbol.parent
 
     def dump(self, lines: List[str]) -> None:
         pass

--- a/rift-engine/rift/ir/IR.py
+++ b/rift-engine/rift/ir/IR.py
@@ -636,7 +636,8 @@ class Symbol:
         """
         return self.scope + self.id
 
-    def get_substring_without_body(self) -> bytes:
+    @property
+    def substring_without_body(self) -> bytes:
         """
         Returns a substring of the code bytes that excludes the body of the IR node.
         If the body_sub attribute is None, returns the full substring of the IR node.
@@ -792,7 +793,7 @@ class File:
             if isinstance(symbol.kind, UnknownKind):
                 pass
             elif not isinstance(symbol.kind, MetaSymbolKind):
-                decl_without_body = symbol.get_substring_without_body().decode().strip()
+                decl_without_body = symbol.substring_without_body.decode().strip()
                 # indent the declaration
                 decl_without_body = decl_without_body.replace("\n", "\n" + " " * indent)
                 lines.append(f"{' ' * indent}{decl_without_body}")

--- a/rift-engine/rift/ir/IR.py
+++ b/rift-engine/rift/ir/IR.py
@@ -673,7 +673,7 @@ class Symbol:
         else:
             id = self.id
         lines.append(
-            f"{self.kind()}: {id}\n   language: {self.language}\n   range: {self.range}\n   substring: {self.substring}"
+            f"{self.name()}: {id}\n   language: {self.language}\n   range: {self.range}\n   substring: {self.substring}"
         )
         if self.scope != "":
             lines.append(f"   scope: {self.scope}")
@@ -689,7 +689,7 @@ class Symbol:
             lines.append(f"   parent: {self.parent.get_qualified_id()}")
         self.symbol_kind.dump(lines)
 
-    def kind(self) -> str:
+    def name(self) -> str:
         return self.symbol_kind.name()
 
 

--- a/rift-engine/rift/ir/IR.py
+++ b/rift-engine/rift/ir/IR.py
@@ -6,6 +6,7 @@ from typing import Callable, Dict, List, Literal, Optional, Tuple, Union
 import numpy as np
 import numpy.typing as npt
 
+
 from . import custom_parsers
 
 Language = Literal[
@@ -234,6 +235,13 @@ class SymbolKind(ABC):
 
     def signature(self) -> Optional[str]:
         return None
+
+    @property
+    def file_path(self) -> Optional[str]:
+        """
+        Returns the file path of the symbol, or None if the symbol is not associated with a file.
+        """
+        return self.symbol.file_path
 
 
 @dataclass
@@ -623,6 +631,18 @@ class Symbol:
     substring_: Substring
     kind: SymbolKind
     embedding: Optional[Vector] = None
+
+    @property
+    def file_path(self) -> Optional[str]:
+        """
+        Returns the file path of the symbol, or None if the symbol is not associated with a file.
+        """
+        symbol = self
+        while not isinstance(symbol.kind, FileKind):
+            if symbol.parent is None:
+                return None
+            symbol = symbol.parent
+        return symbol.id
 
     @property
     def substring(self) -> bytes:

--- a/rift-engine/rift/ir/IR.py
+++ b/rift-engine/rift/ir/IR.py
@@ -223,6 +223,8 @@ SymbolKindName = Literal[
 class SymbolKind(ABC):
     """Abstract class for symbol kinds."""
 
+    symbol: "Symbol"
+
     @abstractmethod
     def name(self) -> SymbolKindName:
         raise NotImplementedError
@@ -709,7 +711,8 @@ def create_file_symbol(code: Code, language: Language, path: str) -> Symbol:
         last_char_in_line = end_byte - last_newline_pos - 1
     range = ((first_line, 0), (last_line, last_char_in_line))
 
-    return Symbol(
+    dummy_kind : SymbolKind = None # type: ignore
+    symbol = Symbol(
         body=Block(),
         body_sub=body_sub,
         code=code,
@@ -721,8 +724,10 @@ def create_file_symbol(code: Code, language: Language, path: str) -> Symbol:
         range=range,
         scope="",
         substring=body_sub,
-        symbol_kind=FileKind(),
+        symbol_kind=dummy_kind,
     )
+    symbol.symbol_kind = FileKind(symbol)
+    return symbol
 
 
 @dataclass

--- a/rift-engine/rift/ir/IR.py
+++ b/rift-engine/rift/ir/IR.py
@@ -620,13 +620,14 @@ class Symbol:
     range: Range
     parent: Optional["Symbol"]
     scope: Scope
-    substring: Substring
+    substring_: Substring
     kind: SymbolKind
     embedding: Optional[Vector] = None
 
-    def get_substring(self) -> bytes:
+    @property
+    def substring(self) -> bytes:
         """Returns the substring of the document that corresponds to this symbol info."""
-        start, end = self.substring
+        start, end = self.substring_
         return self.code.bytes[start:end]
 
     def get_qualified_id(self) -> QualifiedId:
@@ -641,9 +642,9 @@ class Symbol:
         If the body_sub attribute is None, returns the full substring of the IR node.
         """
         if self.body_sub is None:
-            return self.get_substring()
+            return self.substring
         else:
-            start, _end = self.substring
+            start, _end = self.substring_
             body_start, _body_end = self.body_sub
             return self.code.bytes[start:body_start]
 
@@ -671,7 +672,7 @@ class Symbol:
         else:
             id = self.id
         lines.append(
-            f"{self.name()}: {id}\n   language: {self.language}\n   range: {self.range}\n   substring: {self.substring}"
+            f"{self.name()}: {id}\n   language: {self.language}\n   range: {self.range}\n   substring: {self.substring_}"
         )
         if self.scope != "":
             lines.append(f"   scope: {self.scope}")
@@ -721,7 +722,7 @@ def create_file_symbol(code: Code, language: Language, path: str) -> Symbol:
         parent=None,
         range=range,
         scope="",
-        substring=body_sub,
+        substring_=body_sub,
         kind=dummy_kind,
     )
     symbol.kind = FileKind(symbol)

--- a/rift-engine/rift/ir/IR.py
+++ b/rift-engine/rift/ir/IR.py
@@ -681,6 +681,10 @@ class Symbol:
             start, end = self.docstring_sub
             return self.code.bytes[start:end].decode()
 
+    @property
+    def name(self) -> str:
+        return self.kind.name()
+
     def dump(self, lines: List[str]) -> None:
         """
         Appends a string representation of the IR node to the given list of strings.
@@ -694,7 +698,7 @@ class Symbol:
         else:
             id = self.id
         lines.append(
-            f"{self.name()}: {id}\n   language: {self.language}\n   range: {self.range}\n   substring: {self.substring_}"
+            f"{self.name}: {id}\n   language: {self.language}\n   range: {self.range}\n   substring: {self.substring_}"
         )
         if self.scope != "":
             lines.append(f"   scope: {self.scope}")
@@ -709,9 +713,6 @@ class Symbol:
         if self.parent:
             lines.append(f"   parent: {self.parent.qualified_id}")
         self.kind.dump(lines)
-
-    def name(self) -> str:
-        return self.kind.name()
 
 
 def create_file_symbol(code: Code, language: Language, path: str) -> Symbol:

--- a/rift-engine/rift/ir/IR.py
+++ b/rift-engine/rift/ir/IR.py
@@ -630,7 +630,8 @@ class Symbol:
         start, end = self.substring_
         return self.code.bytes[start:end]
 
-    def get_qualified_id(self) -> QualifiedId:
+    @property
+    def qualified_id(self) -> QualifiedId:
         """
         Returns the qualified identifier of the IR node, which is the concatenation of its scope and name.
         """
@@ -686,7 +687,7 @@ class Symbol:
         if self.body != []:
             lines.append(f"   body: {self.body}")
         if self.parent:
-            lines.append(f"   parent: {self.parent.get_qualified_id()}")
+            lines.append(f"   parent: {self.parent.qualified_id}")
         self.kind.dump(lines)
 
     def name(self) -> str:
@@ -771,7 +772,7 @@ class File:
     def add_symbol(self, symbol: Symbol) -> None:
         if symbol.parent:
             symbol.parent.body.append(symbol)
-        self._symbol_table[symbol.get_qualified_id()] = symbol
+        self._symbol_table[symbol.qualified_id] = symbol
 
     def add_import(self, import_: Import) -> None:
         self._imports.append(import_)

--- a/rift-engine/rift/ir/completions.py
+++ b/rift-engine/rift/ir/completions.py
@@ -28,7 +28,7 @@ def get_symbol_completions_raw(project: IR.Project) -> List[Dict[str, Symbol]]:
     for file_ir in project.get_files():
         symbols: List[Symbol] = []
         for symbol in file_ir.search_symbol(lambda _: True):
-            if isinstance(symbol.symbol_kind, IR.MetaSymbolKind):
+            if isinstance(symbol.kind, IR.MetaSymbolKind):
                 continue  # don't emit completions for statements inside bodies
             symbol = Symbol(symbol.id, symbol.scope, symbol.name(), symbol.range)
             symbols.append(symbol)

--- a/rift-engine/rift/ir/completions.py
+++ b/rift-engine/rift/ir/completions.py
@@ -30,7 +30,7 @@ def get_symbol_completions_raw(project: IR.Project) -> List[Dict[str, Symbol]]:
         for symbol in file_ir.search_symbol(lambda _: True):
             if isinstance(symbol.symbol_kind, IR.MetaSymbolKind):
                 continue  # don't emit completions for statements inside bodies
-            symbol = Symbol(symbol.name, symbol.scope, symbol.kind(), symbol.range)
+            symbol = Symbol(symbol.id, symbol.scope, symbol.kind(), symbol.range)
             symbols.append(symbol)
         file = File(file_ir.path, symbols)
         files.append(file)

--- a/rift-engine/rift/ir/completions.py
+++ b/rift-engine/rift/ir/completions.py
@@ -30,7 +30,7 @@ def get_symbol_completions_raw(project: IR.Project) -> List[Dict[str, Symbol]]:
         for symbol in file_ir.search_symbol(lambda _: True):
             if isinstance(symbol.symbol_kind, IR.MetaSymbolKind):
                 continue  # don't emit completions for statements inside bodies
-            symbol = Symbol(symbol.id, symbol.scope, symbol.kind(), symbol.range)
+            symbol = Symbol(symbol.id, symbol.scope, symbol.name(), symbol.range)
             symbols.append(symbol)
         file = File(file_ir.path, symbols)
         files.append(file)

--- a/rift-engine/rift/ir/completions.py
+++ b/rift-engine/rift/ir/completions.py
@@ -30,7 +30,7 @@ def get_symbol_completions_raw(project: IR.Project) -> List[Dict[str, Symbol]]:
         for symbol in file_ir.search_symbol(lambda _: True):
             if isinstance(symbol.kind, IR.MetaSymbolKind):
                 continue  # don't emit completions for statements inside bodies
-            symbol = Symbol(symbol.id, symbol.scope, symbol.name(), symbol.range)
+            symbol = Symbol(symbol.id, symbol.scope, symbol.name, symbol.range)
             symbols.append(symbol)
         file = File(file_ir.path, symbols)
         files.append(file)

--- a/rift-engine/rift/ir/metalanguage.py
+++ b/rift-engine/rift/ir/metalanguage.py
@@ -76,7 +76,7 @@ class MetaLanguage:
                 if isinstance(x, IR.Symbol):
                     if not b:
                         self.report_check_failed(
-                            f"Check failed on {x.get_qualified_id()} in {self.get_file_path(x)}"
+                            f"Check failed on {x.qualified_id} in {self.get_file_path(x)}"
                         )
                 elif isinstance(
                     x, (IR.Field, IR.FunctionKind, IR.Parameter, IR.TypeDefinitionKind)

--- a/rift-engine/rift/ir/metalanguage.py
+++ b/rift-engine/rift/ir/metalanguage.py
@@ -47,28 +47,28 @@ class MetaLanguage:
             if "Class" not in self.locals:
                 classes: List[IR.Symbol] = []
                 for symbol in self._all_symbols:
-                    if isinstance(symbol.symbol_kind, IR.ClassKind):
+                    if isinstance(symbol.kind, IR.ClassKind):
                         classes.append(symbol)
                 self.locals["Class"] = classes
         elif mv == "Function":
             if "Function" not in self.locals:
                 functions: List[IR.FunctionKind] = []
                 for symbol in self._all_symbols:
-                    if isinstance(symbol.symbol_kind, IR.FunctionKind):
-                        f = symbol.symbol_kind
+                    if isinstance(symbol.kind, IR.FunctionKind):
+                        f = symbol.kind
                         self.set_file_path(f, self.get_file_path(symbol))
                         for p in f.parameters:
                             self.set_file_path(p, self.get_file_path(symbol))
-                        functions.append(symbol.symbol_kind)
+                        functions.append(symbol.kind)
                 self.locals["Function"] = functions
         elif mv == "TypeDefinition":
             if "TypeDefinition" not in self.locals:
                 type_definitions: List[IR.TypeDefinitionKind] = []
                 for symbol in self._all_symbols:
-                    if isinstance(symbol.symbol_kind, IR.TypeDefinitionKind):
-                        td = symbol.symbol_kind
+                    if isinstance(symbol.kind, IR.TypeDefinitionKind):
+                        td = symbol.kind
                         self.set_file_path(td, self.get_file_path(symbol))
-                        type_definitions.append(symbol.symbol_kind)
+                        type_definitions.append(symbol.kind)
                 self.locals["TypeDefinition"] = type_definitions
         elif mv == "check":
 

--- a/rift-engine/rift/ir/missing_docstrings.py
+++ b/rift-engine/rift/ir/missing_docstrings.py
@@ -10,7 +10,7 @@ class FunctionMissingDocstring:
 
     def __str__(self) -> str:
         # let agent generate doc string for function by reading the function code
-        return f"Function `{self.function_declaration.name}` is missing a doc string"
+        return f"Function `{self.function_declaration.id}` is missing a doc string"
 
     def __repr__(self) -> str:
         return self.__str__()

--- a/rift-engine/rift/ir/missing_types.py
+++ b/rift-engine/rift/ir/missing_types.py
@@ -12,7 +12,7 @@ class MissingType:
     return_type: bool = False
 
     def __str__(self) -> str:
-        s = f"Function `{self.function_declaration.name}` is missing type annotations"
+        s = f"Function `{self.function_declaration.id}` is missing type annotations"
         if self.parameters != []:
             if len(self.parameters) == 1:
                 s += f" in parameter '{self.parameters[0]}'"

--- a/rift-engine/rift/ir/missing_types.py
+++ b/rift-engine/rift/ir/missing_types.py
@@ -38,7 +38,7 @@ def functions_missing_types_in_file(file: IR.File) -> List[MissingType]:
     for d in function_declarations:
         if d.language not in ["javascript", "ocaml", "python", "rescript", "tsx", "typescript"]:
             continue
-        function_kind = d.symbol_kind
+        function_kind = d.kind
         if not isinstance(function_kind, IR.FunctionKind):
             raise Exception(f"Expected function kind, got {function_kind}")
         missing_parameters: List[str] = []

--- a/rift-engine/rift/ir/parser_core.py
+++ b/rift-engine/rift/ir/parser_core.py
@@ -318,7 +318,7 @@ class SymbolParser:
             range=(parents[0].start_point, parents[-1].end_point),
             scope=self.scope,
             substring=(parents[0].start_byte, parents[-1].end_byte),
-            symbol_kind=symbol_kind,
+            kind=symbol_kind,
         )
 
     def mk_dummy_symbol(self, id: Node | str, parents: List[Node]) -> Symbol:
@@ -328,7 +328,7 @@ class SymbolParser:
             name = id.text.decode()
         dummy_kind: SymbolKind = None  # type: ignore
         symbol = self.mk_symbol_decl(id=name, parents=parents, symbol_kind=dummy_kind)
-        symbol.symbol_kind = ValueKind(symbol)
+        symbol.kind = ValueKind(symbol)
         return symbol
 
     def mk_dummy_metasymbol(self, counter: Counter, name: str) -> Symbol:
@@ -339,7 +339,7 @@ class SymbolParser:
         return dummy
 
     def update_dummy_symbol(self, symbol: Symbol, symbol_kind: SymbolKind) -> None:
-        symbol.symbol_kind = symbol_kind
+        symbol.kind = symbol_kind
 
     def mk_fun_decl(
         self,

--- a/rift-engine/rift/ir/parser_core.py
+++ b/rift-engine/rift/ir/parser_core.py
@@ -775,11 +775,17 @@ class SymbolParser:
             def parse_res_parameters(exp: Node, parameters: List[Parameter]) -> None:
                 nonlocal return_type
                 if exp.type == "function":
+                    parameters_node = exp.child_by_field_name("parameters")
+                    if parameters_node is not None:
+                        for par in parameters_node.children:
+                            parse_res_parameter(par, parameters)
+                    parameter_node = exp.child_by_field_name("parameter")
+                    if parameter_node is not None:
+                        parameters.append(
+                            Parameter(default_value=None, name=parameter_node.text.decode())
+                        )
                     nodes = exp.children
                     if len(nodes) >= 2:
-                        if nodes[0].type == "formal_parameters":
-                            for par in nodes[0].children:
-                                parse_res_parameter(par, parameters)
                         if nodes[1].type == "type_annotation" and nodes[1].child_count >= 2:
                             return_type = parse_type(language, nodes[1].children[1])
                         if self.body_sub is not None:

--- a/rift-engine/rift/ir/parser_core.py
+++ b/rift-engine/rift/ir/parser_core.py
@@ -317,7 +317,7 @@ class SymbolParser:
             parent=self.parent,
             range=(parents[0].start_point, parents[-1].end_point),
             scope=self.scope,
-            substring=(parents[0].start_byte, parents[-1].end_byte),
+            substring_=(parents[0].start_byte, parents[-1].end_byte),
             kind=symbol_kind,
         )
 
@@ -1194,11 +1194,11 @@ class SymbolParser:
         symbols = self.parent.body
 
         # Sort the symbols based on their starting substring index in descending order for accurate replacement
-        sorted_symbols = sorted(symbols, key=lambda s: s.substring[0], reverse=True)
+        sorted_symbols = sorted(symbols, key=lambda s: s.substring_[0], reverse=True)
 
         # Replace each symbol in the code with its name
         for symbol in sorted_symbols:
-            start, end = symbol.substring
+            start, end = symbol.substring_
             # Adjust start and end based on the node's starting byte
             start -= self.node.start_byte
             end -= self.node.start_byte

--- a/rift-engine/rift/ir/parser_core.py
+++ b/rift-engine/rift/ir/parser_core.py
@@ -313,7 +313,7 @@ class SymbolParser:
             docstring_sub=self.docstring_sub,
             exported=self.exported,
             language=self.language,
-            name=name,
+            id=name,
             parent=self.parent,
             range=(parents[0].start_point, parents[-1].end_point),
             scope=self.scope,
@@ -1204,7 +1204,7 @@ class SymbolParser:
             end -= self.node.start_byte
             # Ensure the symbol's start and end are within bounds of the code's length
             if start >= 0 and end <= len(code):
-                code = code[:start] + symbol.name + code[end:]
+                code = code[:start] + symbol.id + code[end:]
 
         return code
 

--- a/rift-engine/rift/ir/response.py
+++ b/rift-engine/rift/ir/response.py
@@ -97,8 +97,8 @@ def replace_functions_in_document(
         if filter and function_in_blocks is not None:
             updated_functions.append(function_in_blocks)
             if replace == Replace.ALL:
-                substring = function_declaration.substring
-                new_bytes = function_in_blocks.get_substring()
+                substring = function_declaration.substring_
+                new_bytes = function_in_blocks.substring
             elif replace == Replace.DOC:
                 if function_in_blocks.docstring is None:
                     logger.warning(f"No docstring for function {function_declaration.id}")
@@ -129,11 +129,11 @@ def replace_functions_in_document(
                         substring = (body_start - old_indent, body_start - old_indent)
                     else:
                         # add the doc comment before the function
-                        old_function_start = function_declaration.substring[0]
+                        old_function_start = function_declaration.substring_[0]
                         old_indent = find_indent(
                             function_declaration.code.bytes, old_function_start
                         )
-                        new_function_start = function_in_blocks.substring[0]
+                        new_function_start = function_in_blocks.substring_[0]
                         new_indent = find_indent(function_in_blocks.code.bytes, new_function_start)
                         substring = (
                             old_function_start - old_indent,
@@ -158,7 +158,7 @@ def replace_functions_in_document(
                     logger.info(f"{new_function_text=}")
                     new_function_text += old_trailing_whitespace.group(0)
                     logger.info(f"{new_function_text=}")
-                start_replace = function_declaration.substring[0]
+                start_replace = function_declaration.substring_[0]
                 end_replace = start_replace + len(old_function_text)
                 substring = (start_replace, end_replace)
                 new_bytes = new_function_text

--- a/rift-engine/rift/ir/response.py
+++ b/rift-engine/rift/ir/response.py
@@ -147,9 +147,9 @@ def replace_functions_in_document(
                 docstring = textwrap.indent(docstring, " " * old_indent)
                 new_bytes = docstring.encode("utf-8") + b"\n"
             elif replace == Replace.SIGNATURE:
-                new_function_text = function_in_blocks.get_substring_without_body()
+                new_function_text = function_in_blocks.substring_without_body
                 logger.info(f"{new_function_text=}")
-                old_function_text = function_declaration.get_substring_without_body()
+                old_function_text = function_declaration.substring_without_body
                 # Get trailing newline and/or whitespace from old text
                 old_trailing_whitespace = re.search(rb"\s*$", old_function_text)
                 # Add it to new text

--- a/rift-engine/rift/ir/response.py
+++ b/rift-engine/rift/ir/response.py
@@ -93,7 +93,7 @@ def replace_functions_in_document(
         if filter_function_ids is None:
             filter = True
         else:
-            filter = function_declaration.get_qualified_id() in filter_function_ids
+            filter = function_declaration.qualified_id in filter_function_ids
         if filter and function_in_blocks is not None:
             updated_functions.append(function_in_blocks)
             if replace == Replace.ALL:

--- a/rift-engine/rift/ir/response.py
+++ b/rift-engine/rift/ir/response.py
@@ -88,7 +88,7 @@ def replace_functions_in_document(
         function_in_blocks = None
         if len(function_in_blocks_) == 1:
             f0 = function_in_blocks_[0]
-            if isinstance(f0.symbol_kind, IR.FunctionKind):
+            if isinstance(f0.kind, IR.FunctionKind):
                 function_in_blocks = f0
         if filter_function_ids is None:
             filter = True
@@ -177,8 +177,8 @@ def update_typing_imports(
     if typing_import is not None:
         typing_names = set(typing_import.names)
     for f in updated_functions:
-        if isinstance(f.symbol_kind, IR.FunctionKind):
-            fun_kind = f.symbol_kind
+        if isinstance(f.kind, IR.FunctionKind):
+            fun_kind = f.kind
             types_in_function = [p.type for p in fun_kind.parameters if p.type is not None]
             if fun_kind.return_type is not None:
                 types_in_function.append(fun_kind.return_type)

--- a/rift-engine/rift/ir/response.py
+++ b/rift-engine/rift/ir/response.py
@@ -84,7 +84,7 @@ def replace_functions_in_document(
     updated_functions: List[IR.Symbol] = []
 
     for function_declaration in function_declarations_in_document:
-        function_in_blocks_ = ir_blocks.search_symbol(function_declaration.name)
+        function_in_blocks_ = ir_blocks.search_symbol(function_declaration.id)
         function_in_blocks = None
         if len(function_in_blocks_) == 1:
             f0 = function_in_blocks_[0]
@@ -101,11 +101,11 @@ def replace_functions_in_document(
                 new_bytes = function_in_blocks.get_substring()
             elif replace == Replace.DOC:
                 if function_in_blocks.docstring is None:
-                    logger.warning(f"No docstring for function {function_declaration.name}")
+                    logger.warning(f"No docstring for function {function_declaration.id}")
                     continue
                 if function_declaration.docstring_sub is not None:
                     logger.warning(
-                        f"Docstring already exists for function {function_declaration.name}"
+                        f"Docstring already exists for function {function_declaration.id}"
                     )
                     continue
 
@@ -140,7 +140,7 @@ def replace_functions_in_document(
                             old_function_start - old_indent,
                         )
                 else:
-                    logger.warning(f"No body for function {function_declaration.name}")
+                    logger.warning(f"No body for function {function_declaration.id}")
                     continue
 
                 docstring = textwrap.dedent(" " * new_indent + function_in_blocks.docstring)

--- a/rift-engine/rift/ir/response_test.txt
+++ b/rift-engine/rift/ir/response_test.txt
@@ -78,7 +78,7 @@ class TestAddDocs:
         Spans multiple lines
         """
         def dump_symbol(symbol: SymbolInfo) -> None:
-            decl_without_body = symbol.get_substring_without_body().decode()
+            decl_without_body = symbol.substring_without_body.decode()
             elements.append(decl_without_body)
             if isinstance(symbol, ContainerDeclaration):
                 for statement in symbol.body:

--- a/rift-engine/rift/ir/test_completions.py
+++ b/rift-engine/rift/ir/test_completions.py
@@ -53,6 +53,6 @@ def test_symbol_reference():
     assert res_some_function is not None
     assert res_some_function.symbol is not None
     assert (
-        res_some_function.symbol.get_substring_without_body().decode().strip()
+        res_some_function.symbol.substring_without_body.decode().strip()
         == "def some_function(self, x: int, y: int) -> int:"
     )

--- a/rift-engine/rift/ir/test_response.py
+++ b/rift-engine/rift/ir/test_response.py
@@ -151,7 +151,7 @@ class Test:
         class TestAddDocs:
             def dump_elements(self, elements: List[str]) -> None:
                 def dump_symbol(symbol: SymbolInfo) -> None:
-                    decl_without_body = symbol.get_substring_without_body().decode()
+                    decl_without_body = symbol.substring_without_body.decode()
                     elements.append(decl_without_body)
                     if isinstance(symbol, ContainerDeclaration):
                         for statement in symbol.body:

--- a/rift-engine/rift/ir/test_response.py
+++ b/rift-engine/rift/ir/test_response.py
@@ -303,7 +303,7 @@ def test_response():
     file = IR.File(IR.Code(Test.response3.encode()), "response3")
     parser.parse_code_block(file, IR.Code(Test.code3), language)
     missing_types = functions_missing_types_in_file(file)
-    filter_function_ids = [mt.function_declaration.get_qualified_id() for mt in missing_types]
+    filter_function_ids = [mt.function_declaration.qualified_id for mt in missing_types]
     document3 = IR.Code(Test.code3)
     edits3, updated_functions = response.replace_functions_from_code_blocks(
         code_blocks=code_blocks3,
@@ -326,7 +326,7 @@ def test_response():
     file = IR.File(IR.Code(Test.response4.encode()), "response4")
     parser.parse_code_block(file, IR.Code(Test.code4), language)
     missing_docs = functions_missing_docstrings_in_file(file)
-    filter_function_ids = [md.function_declaration.get_qualified_id() for md in missing_docs]
+    filter_function_ids = [md.function_declaration.qualified_id for md in missing_docs]
     document4 = IR.Code(Test.code4)
     edits4, updated_functions = response.replace_functions_from_code_blocks(
         code_blocks=code_blocks4,
@@ -343,7 +343,7 @@ def test_response():
     file = IR.File(IR.Code(Test.response5.encode()), "response5")
     parser.parse_code_block(file, IR.Code(Test.code5), language)
     missing_docs = functions_missing_docstrings_in_file(file)
-    filter_function_ids = [md.function_declaration.get_qualified_id() for md in missing_docs]
+    filter_function_ids = [md.function_declaration.qualified_id for md in missing_docs]
     document5 = IR.Code(Test.code5)
     edits5, updated_functions = response.replace_functions_from_code_blocks(
         code_blocks=code_blocks5,

--- a/rift-engine/rift/util/context.py
+++ b/rift-engine/rift/util/context.py
@@ -34,7 +34,7 @@ def lookup_match(match: str, server: "Server") -> str:
         reference_some_function = IR.Reference.from_uri(match)
         symbol_ref = project.lookup_reference(reference_some_function)
         if symbol_ref is not None and symbol_ref.symbol is not None:
-            body = symbol_ref.symbol.get_substring().decode().strip()
+            body = symbol_ref.symbol.substring.decode().strip()
             logger.info(f"[lookup_match] symbol reference found")
             return body
 


### PR DESCRIPTION
Symbol kind now has a field `symbol`, so all the properties of a symbol are now accessible to kinds too.
A bunch of renamings and computed properties, so if `s` is a symbol for function `foo` then `s.id` is `"foo"` and `s.name` is `"Function"`, and `s.kind` is its kind. Also, `id` and `name` are equally available on the kind. And one has `s.kind.symbol == s` so it's possible to go back to symbol from symbol kind.
Also added a computed property `file_path` that applies to symbols and kinds.
