### PR TITLE
IR: split out per-language parsers into separate files

### DIFF
--- a/rift-engine/rift/ir/parser.py
+++ b/rift-engine/rift/ir/parser.py
@@ -4,7 +4,9 @@ from typing import Callable, List, Optional
 from tree_sitter import Parser
 from tree_sitter_languages import get_parser as get_tree_sitter_parser
 
-from . import IR, custom_parsers, parser_core, parser_ocaml
+from rift.ir import parser_rescript
+
+from . import IR, custom_parsers, parser_core, parser_ocaml, parser_rescript
 
 
 def get_parser(language: IR.Language) -> Parser:
@@ -27,6 +29,8 @@ def parse_code_block(
     tree = parser.parse(code.bytes)
     if language == "ocaml":
         constructor = parser_ocaml.OCamlParser
+    elif language == "rescript":
+        constructor = parser_rescript.ReScriptParser
     else:
         constructor = parser_core.SymbolParser
     symbol_parser = constructor(

--- a/rift-engine/rift/ir/parser.py
+++ b/rift-engine/rift/ir/parser.py
@@ -6,7 +6,7 @@ from tree_sitter_languages import get_parser as get_tree_sitter_parser
 
 from rift.ir import parser_rescript
 
-from . import IR, custom_parsers, parser_core, parser_ocaml, parser_rescript
+from . import IR, custom_parsers, parser_core, parser_lean, parser_ocaml, parser_rescript
 
 
 def get_parser(language: IR.Language) -> Parser:
@@ -31,6 +31,8 @@ def parse_code_block(
         constructor = parser_ocaml.OCamlParser
     elif language == "rescript":
         constructor = parser_rescript.ReScriptParser
+    elif language == "lean":
+        constructor = parser_lean.LeanParser
     else:
         constructor = parser_core.SymbolParser
     symbol_parser = constructor(

--- a/rift-engine/rift/ir/parser.py
+++ b/rift-engine/rift/ir/parser.py
@@ -4,7 +4,7 @@ from typing import Callable, List, Optional
 from tree_sitter import Parser
 from tree_sitter_languages import get_parser as get_tree_sitter_parser
 
-from . import IR, custom_parsers, parser_core
+from . import IR, custom_parsers, parser_core, parser_ocaml
 
 
 def get_parser(language: IR.Language) -> Parser:
@@ -25,7 +25,11 @@ def parse_code_block(
 ) -> None:
     parser = get_parser(language)
     tree = parser.parse(code.bytes)
-    parser_core.SymbolParser(
+    if language == "ocaml":
+        constructor = parser_ocaml.OCamlParser
+    else:
+        constructor = parser_core.SymbolParser
+    symbol_parser = constructor(
         code=code,
         file=file,
         language=language,
@@ -33,7 +37,8 @@ def parse_code_block(
         node=tree.root_node,
         parent=file.symbol,
         scope="",
-    ).parse_block()
+    )
+    symbol_parser.parse_block()
 
 
 def parse_path(

--- a/rift-engine/rift/ir/parser_core.py
+++ b/rift-engine/rift/ir/parser_core.py
@@ -11,7 +11,6 @@ from .IR import (
     Case,
     ClassKind,
     Code,
-    DefKind,
     Expression,
     ExpressionKind,
     File,
@@ -26,12 +25,9 @@ from .IR import (
     NamespaceKind,
     Parameter,
     Scope,
-    SectionKind,
-    StructureKind,
     Substring,
     Symbol,
     SymbolKind,
-    TheoremKind,
     Type,
     TypeDefinitionKind,
     UnknownKind,
@@ -609,53 +605,6 @@ class SymbolParser:
                     declaration = self.mk_type_decl(id=id, parents=[node])
                 self.file.add_symbol(declaration)
                 return [declaration]
-
-        elif language == "lean":
-            if node.type == "declaration" and len(node.children) >= 1:
-                node0 = node.children[-1]
-                body_node = node0.child_by_field_name("body")
-                if body_node is not None:
-                    self.body_sub = (body_node.start_byte, body_node.end_byte)
-                name_node = node0.child_by_field_name("name")
-                if name_node is not None:
-                    symbol = None
-                    if node0.type == "def":
-                        symbol = self.mk_dummy_symbol(id=name_node, parents=[node])
-                        self.update_dummy_symbol(symbol, DefKind(symbol))
-                    elif node0.type == "structure":
-                        # a structure/class does not have a body
-                        node_after_name = name_node.next_sibling
-                        if node_after_name is not None:
-                            self.body_sub = (node_after_name.start_byte, node.end_byte)
-                        symbol = self.mk_dummy_symbol(id=name_node, parents=[node])
-                        self.update_dummy_symbol(symbol, StructureKind(symbol))
-                    elif node0.type == "theorem":
-                        symbol = self.mk_dummy_symbol(id=name_node, parents=[node])
-                        self.update_dummy_symbol(symbol, TheoremKind(symbol))
-                    else:
-                        logger.warning(f"Lean: Unknown node0 type: {node0.type}")
-                    if symbol is not None:
-                        self.file.add_symbol(symbol)
-                        return [symbol]
-            elif node.type == "comment":
-                pass
-            elif node.type in ["namespace", "section"] and node.child_count >= 3:
-                # section, id, ..., id
-                name = node.children[1]
-                self.body_sub = (name.end_byte, node.end_byte)
-                new_scope = self.scope + name.text.decode() + "."
-                symbol = self.mk_dummy_symbol(id=name, parents=[node])
-                self.recurse(node, new_scope, parent=symbol).parse_block()
-                if node.type == "namespace":
-                    self.update_dummy_symbol(symbol, NamespaceKind(symbol))
-                else:
-                    self.update_dummy_symbol(symbol, SectionKind(symbol))
-                self.file.add_symbol(symbol)
-                return [symbol]
-            elif node.type == "end":
-                pass
-            else:
-                logger.warning(f"Lean: Unknown node type: {node.type}")
 
         if self.metasymbols:
             metasymbol = self.parse_metasymbol(counter)

--- a/rift-engine/rift/ir/parser_core.py
+++ b/rift-engine/rift/ir/parser_core.py
@@ -14,7 +14,6 @@ from .IR import (
     DefKind,
     Expression,
     ExpressionKind,
-    Field,
     File,
     ForKind,
     FunctionKind,
@@ -30,7 +29,6 @@ from .IR import (
     SectionKind,
     StructureKind,
     Substring,
-    SwitchKind,
     Symbol,
     SymbolKind,
     TheoremKind,
@@ -68,23 +66,6 @@ def parse_type(language: Language, node: Node, parent: Symbol) -> Type:
         elif child.type == "identifier":
             name = child.text.decode()
             return Type.constructor(name=name, parent=parent)
-    elif language == "rescript":
-        if node.type == "type_identifier":
-            name = node.text.decode()
-            return Type.constructor(name=name, parent=parent)
-        elif node.type == "generic_type" and node.child_count == 2:
-            name = node.children[0].text.decode()
-            arguments_node = node.children[1]
-            if arguments_node.type == "type_arguments":
-                # remove first and last argument: < and >
-                arguments = arguments_node.children[1:-1]
-                arguments = [parse_type(language, n, parent) for n in arguments]
-                t = Type.constructor(name=name, arguments=arguments, parent=parent)
-                return t
-            else:
-                logger.warning(f"Unknown arguments_node type node: {arguments_node}")
-        else:
-            logger.warning(f"Unknown type node: {node}")
 
     return Type.unknown(node.text.decode(), parent)
 
@@ -629,253 +610,6 @@ class SymbolParser:
                 self.file.add_symbol(declaration)
                 return [declaration]
 
-        elif node.type == "let_declaration" and language == "rescript":
-            return_type = None
-
-            def parse_res_parameter(par: Node, parameters: List[Parameter], parent: Symbol) -> None:
-                if par.type in ["(", ")", ","]:
-                    pass
-                elif par.type == "parameter" and par.child_count >= 1:
-                    nodes = par.children
-                    type: Optional[Type] = None
-                    if (
-                        len(nodes) >= 2
-                        and nodes[1].type == "type_annotation"
-                        and len(nodes[1].children) >= 2
-                    ):
-                        type = parse_type(language, nodes[1].children[1], parent)
-                    default_value = None
-                    if nodes[0].type == "labeled_parameter":
-                        children = nodes[0].children
-                        default_value_node = nodes[0].child_by_field_name("default_value")
-                        if default_value_node is not None:
-                            next = default_value_node.next_sibling
-                            if next is not None:
-                                default_value = next.text.decode()
-                        for child in children:
-                            if child.type == "type_annotation" and len(child.children) >= 2:
-                                type = parse_type(language, child.children[1], parent)
-                        name = "~" + children[1].text.decode()
-                    else:
-                        name = nodes[0].text.decode()
-                    parameters.append(
-                        Parameter(default_value=default_value, name=name, type=type, parent=parent)
-                    )
-                else:
-                    logger.warning(f"Unexpected parameter type: {par.type}")
-
-            def parse_res_parameters(
-                exp: Node, parameters: List[Parameter], parent: Symbol
-            ) -> None:
-                nonlocal return_type
-                if exp.type == "function":
-                    parameters_node = exp.child_by_field_name("parameters")
-                    if parameters_node is not None:
-                        for par in parameters_node.children:
-                            parse_res_parameter(par, parameters, parent)
-                    parameter_node = exp.child_by_field_name("parameter")
-                    if parameter_node is not None:
-                        parameters.append(
-                            Parameter(
-                                default_value=None, name=parameter_node.text.decode(), parent=parent
-                            )
-                        )
-                    nodes = exp.children
-                    if len(nodes) >= 2:
-                        if nodes[1].type == "type_annotation" and nodes[1].child_count >= 2:
-                            return_type = parse_type(language, nodes[1].children[1], parent)
-                        if self.body_sub is not None:
-                            self.body_sub = (nodes[-2].start_byte, self.body_sub[1])
-
-            def parse_res_body(exp: Node, parent: Symbol, id_name: str) -> None:
-                if exp.type == "function":
-                    body_node = exp.child_by_field_name("body")
-                    if body_node is not None:
-                        counter = Counter()
-                        scope = self.scope + id_name + "."
-                        self.recurse(body_node, scope, parent=parent).parse_expression(counter)
-
-            def parse_res_let_binding(nodes: List[Node], parents: List[Node]) -> Optional[Symbol]:
-                id = None
-                exp = None
-                typ = None
-                if len(nodes) == 0:
-                    pass
-                elif (
-                    len(nodes) == 3
-                    and nodes[0].type == "value_identifier"
-                    and nodes[1].text == b"="
-                ):
-                    id = nodes[0]
-                    exp = nodes[2]
-                    self.body_sub = (nodes[1].start_byte, exp.end_byte)
-                elif (
-                    len(nodes) > 2
-                    and nodes[0].type == "parenthesized_pattern"
-                    and nodes[1].type == "="
-                ):
-                    pat = nodes[0].children[1:-1]  # remove ( and )
-                    return parse_res_let_binding(pat + nodes[1:], parents)
-                elif (
-                    len(nodes) == 4 and nodes[1].type == "type_annotation" and nodes[2].type == "="
-                ):
-                    id = nodes[0]
-                    typ = nodes[1]
-                    exp = nodes[3]
-                    self.body_sub = (nodes[2].start_byte, exp.end_byte)
-                elif len(nodes) == 4 and nodes[1].type == "as_aliasing" and nodes[2].type == "=":
-                    id = nodes[1].children[1]
-                    exp = nodes[3]
-                    self.body_sub = (nodes[2].start_byte, exp.end_byte)
-                elif nodes[0].type in ["tuple_pattern", "unit"]:
-                    pass
-                else:
-                    print(f"Unexpected let_binding nodes:{nodes}")
-                if id is not None and id.text != b"_":
-                    parameters: List[Parameter] = []
-                    symbol = self.mk_dummy_symbol(id=id, parents=parents)
-                    if exp is not None:
-                        parse_res_parameters(exp, parameters, parent=symbol)
-                    if parameters == []:
-                        type: Optional[Type] = None
-                        if typ is not None and typ.child_count >= 2:
-                            type = parse_type(language, typ.children[1], symbol)
-                        symbol_kind = ValueKind(type=type, symbol=symbol)
-                        self.update_dummy_symbol(symbol, symbol_kind)
-                    else:
-                        symbol_kind = FunctionKind(
-                            has_return=self.has_return,
-                            parameters=parameters,
-                            return_type=return_type,
-                            symbol=symbol,
-                        )
-                        self.update_dummy_symbol(symbol, symbol_kind)
-                    if exp is not None:
-                        parse_res_body(exp, symbol, id.text.decode())
-                    self.file.add_symbol(symbol)
-                    return symbol
-
-            declarations: List[Symbol] = []
-            for child in node.children:
-                if child.type == "let_binding":
-                    parents = [n for n in (child.prev_sibling, child) if n]
-                    # let rec: add node of type "let" if present before the first parent
-                    if (
-                        len(parents) > 0
-                        and parents[0].prev_sibling is not None
-                        and parents[0].prev_sibling.type == "let"
-                    ):
-                        parents = [parents[0].prev_sibling] + parents
-                    decl = parse_res_let_binding(nodes=child.children, parents=parents)
-                    if decl is not None:
-                        declarations.append(decl)
-            return declarations
-
-        elif node.type == "module_declaration" and language == "rescript":
-
-            def parse_module_binding(nodes: List[Node]) -> List[Symbol]:
-                id = None
-                body = None
-                if (
-                    len(nodes) == 3
-                    and nodes[0].type == "module_identifier"
-                    and nodes[1].type == "="
-                ):
-                    id = nodes[0]
-                    body = nodes[2]
-                    self.body_sub = (nodes[0].end_byte, nodes[2].end_byte)
-                elif (
-                    len(nodes) == 5
-                    and nodes[0].type == "module_identifier"
-                    and nodes[1].type == ":"
-                    and nodes[3].type == "="
-                ):
-                    id = nodes[0]
-                    body = nodes[4]
-                    self.body_sub = (nodes[0].end_byte, nodes[4].end_byte)
-                else:
-                    print(f"Unexpected module_binding nodes:{len(nodes)}")
-                if id is not None and body is not None:
-                    new_scope = self.scope + id.text.decode() + "."
-                    symbol = self.mk_dummy_symbol(id=id, parents=[node])
-                    self.recurse(body, new_scope, parent=symbol).parse_block()
-                    self.update_dummy_symbol(symbol, ModuleKind(symbol))
-                    self.file.add_symbol(symbol)
-                    return [symbol]
-                else:
-                    return []
-
-            if len(node.children) == 2:
-                m1 = node.children[1]
-                if m1.type == "module_binding":
-                    nodes = m1.children
-                    return parse_module_binding(nodes)
-                else:
-                    logger.warning(f"Unexpected node type in module_declaration: {m1.type}")
-
-        elif node.type == "type_declaration" and language == "rescript":
-
-            def parse_type_body(body: Node, parent: Symbol) -> Optional[Type]:
-                if body.type == "record_type":
-                    fields: List[Field] = []
-                    for f in body.children:
-                        if f.type == "record_type_field":
-                            children = f.children
-                            field = None
-                            if (
-                                len(children) == 3
-                                and children[0].type == "property_identifier"
-                                and children[1].type == "?"
-                                and children[2].type == "type_annotation"
-                            ):
-                                fname = children[0].text.decode()
-                                optional = True
-                                type = parse_type(language, children[2].children[1], parent)
-                                field = Field(fname, optional, parent, type)
-                            elif (
-                                len(children) == 2
-                                and children[0].type == "property_identifier"
-                                and children[1].type == "type_annotation"
-                            ):
-                                fname = children[0].text.decode()
-                                optional = False
-                                type = parse_type(language, children[1].children[1], parent)
-                                field = Field(fname, optional, parent, type)
-                            else:
-                                logger.warning(
-                                    f"Unexpected node structure in record_type_field: {f.text.decode()}"
-                                )
-                            if field is not None:
-                                fields.append(field)
-                    return Type.record(fields, parent=parent)
-                else:
-                    logger.warning(f"Unexpected node type in type_declaration: {body.type}")
-                    return None
-
-            if len(node.children) == 2:
-                t1 = node.children[1]
-                node_name = t1.child_by_field_name("name")
-                node_body = t1.child_by_field_name("body")
-                if t1.type == "type_binding" and node_name is not None:
-                    symbol = self.mk_dummy_symbol(id=node_name, parents=[node])
-                    type = None
-                    if node_body is not None:
-                        type = parse_type_body(node_body, symbol)
-                    elif len(t1.children) == 3 and t1.children[1].type == "=":
-                        type = parse_type(language, t1.children[2], symbol)
-                    else:
-                        logger.warning(
-                            f"Unexpected node structure in type_binding: {t1.text.decode()}"
-                        )
-                    if type is not None:
-                        symbol_kind = TypeDefinitionKind(symbol, type)
-                        self.update_dummy_symbol(symbol, symbol_kind)
-                        self.file.add_symbol(symbol)
-                        return [symbol]
-                else:
-                    logger.warning(f"Unexpected node type in type_declaration: {t1.type}")
-                return []
-
         elif language == "lean":
             if node.type == "declaration" and len(node.children) >= 1:
                 node0 = node.children[-1]
@@ -1004,27 +738,6 @@ class SymbolParser:
                 self.file.add_symbol(if_symbol)
                 return if_symbol
 
-        elif node.type == "if_expression" and language in ["rescript"] and node.child_count >= 3:
-            guard_node = node.children[1]
-            body_node = node.children[2]
-            else_node = None
-            if node.child_count >= 4:
-                else_node = node.children[3]
-            if_symbol = self.mk_dummy_metasymbol(counter, "if")
-            scope = self.scope
-            if_guard = self.recurse(guard_node, scope, parent=if_symbol).parse_guard(counter)
-            if_body = self.recurse(body_node, scope, parent=if_symbol).parse_body(counter)
-            if_case = Case(guard=if_guard, body=if_body)
-            else_body = None
-            if else_node is not None and else_node.child_count >= 2:
-                else_body = self.recurse(else_node.children[1], scope, parent=if_symbol).parse_body(
-                    counter
-                )
-            if_kind = IfKind(if_symbol, if_case=if_case, elif_cases=[], else_body=else_body)
-            self.update_dummy_symbol(symbol=if_symbol, symbol_kind=if_kind)
-            self.file.add_symbol(if_symbol)
-            return if_symbol
-
         elif node.type == "for_statement" and language == "python":
             left_node = node.child_by_field_name("left")
             right_node = node.child_by_field_name("right")
@@ -1040,11 +753,7 @@ class SymbolParser:
                 self.file.add_symbol(for_symbol)
                 return for_symbol
 
-        elif (
-            node.type == "expression_statement"
-            and language in ["python", "rescript"] + jslangs
-            and node.child_count == 1
-        ):
+        elif node.type == "expression_statement" and node.child_count == 1:
             child = node.children[0]
             if self.expression_requires_node(child) and self.parent:
                 # Don't need to create a sybmol as parsing the expression will create one
@@ -1060,33 +769,6 @@ class SymbolParser:
                 self.update_dummy_symbol(symbol=symbol, symbol_kind=ExpressionKind(symbol, code))
                 self.file.add_symbol(symbol)
                 return symbol
-
-        elif node.type == "switch_expression" and language in ["rescript"]:
-            if node.child_count >= 3:
-                switch_symbol = self.mk_dummy_metasymbol(counter, "switch")
-                scope = self.scope
-                expression_node = node.children[1]
-                expression = self.recurse(expression_node, scope, parent=switch_symbol).parse_guard(
-                    counter
-                )
-                cases: List[Case] = []
-                for case_node in node.children[2:]:
-                    pattern_node = case_node.child_by_field_name("pattern")
-                    body_node = case_node.child_by_field_name("body")
-                    if pattern_node is not None and body_node is not None:
-                        pattern = self.recurse(
-                            pattern_node, scope, parent=switch_symbol
-                        ).parse_guard(counter)
-                        body = self.recurse(body_node, scope, parent=switch_symbol).parse_body(
-                            counter
-                        )
-                        cases.append(Case(guard=pattern, body=body))
-                switch_kind = SwitchKind(
-                    switch_symbol, expression=expression, cases=cases, default=None
-                )
-                self.update_dummy_symbol(symbol=switch_symbol, symbol_kind=switch_kind)
-                self.file.add_symbol(switch_symbol)
-                return switch_symbol
 
     def parse_expression(self, counter: Counter) -> Expression:
         """
@@ -1127,7 +809,6 @@ class SymbolParser:
 
     def walk_expression(self, counter: Counter) -> None:
         node = self.node
-        symbol: Optional[Symbol] = None
         if self.expression_requires_node(node):
             if node.type in ["call", "call_expression"]:
                 function_node = node.child_by_field_name("function")
@@ -1155,10 +836,6 @@ class SymbolParser:
                     self.file.add_symbol(symbol)
             else:
                 logger.warning(f"Unexpected expression: {node.type}")
-        elif node.type in ["if_expression", "switch_expression"] and self.language == "rescript":
-            self.parse_symbols(counter)
-        elif node.type == "block" and self.language == "rescript":
-            self.parse_block()
         elif node.type in ["await", "assignment", "binary_operator", "parenthesized_expression"]:
             for child in node.children:
                 self.node = child

--- a/rift-engine/rift/ir/parser_core.py
+++ b/rift-engine/rift/ir/parser_core.py
@@ -287,7 +287,7 @@ class SymbolParser:
         self.has_return = False
 
     def recurse(self, node: Node, scope: Scope, parent: Optional[Symbol]) -> "SymbolParser":
-        return SymbolParser(
+        return self.__class__(
             code=self.code,
             file=self.file,
             language=self.language,
@@ -412,9 +412,7 @@ class SymbolParser:
         return self.node
 
     def process_body(self) -> Optional[Node]:
-        if self.language == "ocaml":
-            pass  # handled for each declaration in a let binding
-        elif self.language == "ruby":
+        if self.language == "ruby":
             return self.process_ruby_body()
         else:
             body_node = self.node.child_by_field_name("body")
@@ -630,125 +628,6 @@ class SymbolParser:
                     declaration = self.mk_type_decl(id=id, parents=[node])
                 self.file.add_symbol(declaration)
                 return [declaration]
-
-        elif node.type == "value_definition" and language == "ocaml":
-            parameters = []
-
-            def extract_type(node: Node, parent: Symbol) -> Type:
-                return parse_type(language, node, parent)
-
-            def parse_inner_parameter(inner: Node, parent: Symbol) -> Optional[Parameter]:
-                if inner.type in ["label_name", "value_pattern"]:
-                    name = inner.text.decode()
-                    return Parameter(name=name, parent=parent)
-                elif (
-                    inner.type == "typed_pattern"
-                    and inner.child_count == 5
-                    and inner.children[2].type == ":"
-                ):
-                    # "(", par, ":", typ, ")"
-                    id = inner.children[1]
-                    tp = inner.children[3]
-                    if id.type == "value_pattern":
-                        name = id.text.decode()
-                        type = extract_type(tp, parent)
-                        return Parameter(name=name, type=type, parent=parent)
-                elif inner.type == "unit":
-                    name = "()"
-                    type = Type.constructor(name="unit", parent=parent)
-                    return Parameter(name=name, type=type, parent=parent)
-
-            def parse_ocaml_parameter(parameter: Node, parent: Symbol) -> None:
-                if parameter.child_count == 1:
-                    inner_parameter = parse_inner_parameter(parameter.children[0], parent)
-                    if inner_parameter is not None:
-                        parameters.append(inner_parameter)
-                elif parameter.child_count == 2 and parameter.children[0].type in ["~", "?"]:
-                    inner_parameter = parse_inner_parameter(parameter.children[1], parent)
-                    if inner_parameter is not None:
-                        inner_parameter.name = parameter.children[0].type + inner_parameter.name
-                        parameters.append(inner_parameter)
-                elif (
-                    parameter.child_count == 4
-                    and parameter.children[0].type in ["~", "?"]
-                    and parameter.children[2].type == ":"
-                ):
-                    # "~", par, ":", name
-                    inner_parameter = parse_inner_parameter(parameter.children[1], parent)
-                    if inner_parameter is not None:
-                        inner_parameter.name = parameter.children[0].type + inner_parameter.name
-                        parameters.append(inner_parameter)
-                elif (
-                    parameter.child_count == 6
-                    and parameter.children[0].type in ["~", "?"]
-                    and parameter.children[3].type == ":"
-                ):
-                    # "~", "(", par, ":", typ, ")"
-                    inner_parameter = parse_inner_parameter(parameter.children[2], parent)
-                    if inner_parameter is not None:
-                        inner_parameter.name = parameter.children[0].type + inner_parameter.name
-                        type = extract_type(parameter.children[4], parent)
-                        inner_parameter.type = type
-                        parameters.append(inner_parameter)
-                elif (
-                    parameter.child_count == 6
-                    and parameter.children[0].type == "?"
-                    and parameter.children[3].type == "="
-                ):
-                    # "?", "(", par, "=", val, ")"
-                    inner_parameter = parse_inner_parameter(parameter.children[2], parent)
-                    if inner_parameter is not None:
-                        inner_parameter.name = parameter.children[0].type + inner_parameter.name
-                        type = extract_type(parameter.children[4], parent).type_of(parent)
-                        inner_parameter.type = type
-                        parameters.append(inner_parameter)
-
-            declarations: List[Symbol] = []
-            for child in node.children:
-                if child.type == "let_binding":
-                    pattern_node = child.child_by_field_name("pattern")
-                    if pattern_node is not None and pattern_node.type == "value_name":
-                        parents = [n for n in (child.prev_sibling, child) if n]
-                        # let rec: add node of type "let" if present before the first parent
-                        if (
-                            len(parents) > 0
-                            and parents[0].prev_sibling is not None
-                            and parents[0].prev_sibling.type == "let"
-                        ):
-                            parents = [parents[0].prev_sibling] + parents
-                        symbol = self.mk_dummy_symbol(id=pattern_node, parents=parents)
-                        for grandchild in child.children:
-                            if grandchild.type == "parameter":
-                                parse_ocaml_parameter(grandchild, parent=symbol)
-                        return_type, _ = self.process_ocaml_body(child, parent=symbol)
-                        if parameters != []:
-                            symbol_kind = FunctionKind(
-                                has_return=self.has_return,
-                                parameters=parameters,
-                                return_type=return_type,
-                                symbol=symbol,
-                            )
-                            self.update_dummy_symbol(symbol, symbol_kind)
-                        else:
-                            symbol_kind = ValueKind(type=return_type, symbol=symbol)
-                            self.update_dummy_symbol(symbol, symbol_kind)
-                        self.file.add_symbol(symbol)
-                        declarations.append(symbol)
-            return declarations
-
-        elif node.type == "module_definition" and language == "ocaml":
-            for child in node.children:
-                if child.type == "module_binding":
-                    name = child.child_by_field_name("name")
-                    if name is not None:
-                        new_scope = self.scope + name.text.decode() + "."
-                        symbol = self.mk_dummy_symbol(id=name, parents=[node])
-                        _, body_node = self.process_ocaml_body(child, parent=symbol)
-                        if body_node is not None:
-                            self.recurse(body_node, new_scope, parent=symbol).parse_block()
-                        self.update_dummy_symbol(symbol, ModuleKind(symbol))
-                        self.file.add_symbol(symbol)
-                        return [symbol]
 
         elif node.type == "let_declaration" and language == "rescript":
             return_type = None

--- a/rift-engine/rift/ir/parser_lean.py
+++ b/rift-engine/rift/ir/parser_lean.py
@@ -1,0 +1,47 @@
+import logging
+from typing import List
+
+
+from rift.ir.parser_core import Counter, SymbolParser
+
+from .IR import (
+    DefKind,
+    StructureKind,
+    Symbol,
+    TheoremKind,
+)
+
+logger = logging.getLogger(__name__)
+
+
+class LeanParser(SymbolParser):
+    def parse_symbols(self, counter: Counter) -> List[Symbol]:
+        node = self.node
+        if node.type == "declaration" and len(node.children) >= 1:
+            node0 = node.children[-1]
+            body_node = node0.child_by_field_name("body")
+            if body_node is not None:
+                self.body_sub = (body_node.start_byte, body_node.end_byte)
+            name_node = node0.child_by_field_name("name")
+            if name_node is not None:
+                symbol = None
+                if node0.type == "def":
+                    symbol = self.mk_dummy_symbol(id=name_node, parents=[node])
+                    self.update_dummy_symbol(symbol, DefKind(symbol))
+                elif node0.type == "structure":
+                    # a structure/class does not have a body
+                    node_after_name = name_node.next_sibling
+                    if node_after_name is not None:
+                        self.body_sub = (node_after_name.start_byte, node.end_byte)
+                    symbol = self.mk_dummy_symbol(id=name_node, parents=[node])
+                    self.update_dummy_symbol(symbol, StructureKind(symbol))
+                elif node0.type == "theorem":
+                    symbol = self.mk_dummy_symbol(id=name_node, parents=[node])
+                    self.update_dummy_symbol(symbol, TheoremKind(symbol))
+                else:
+                    logger.warning(f"Lean: Unknown node0 type: {node0.type}")
+                if symbol is not None:
+                    self.file.add_symbol(symbol)
+                    return [symbol]
+
+        return super().parse_symbols(counter)

--- a/rift-engine/rift/ir/parser_ocaml.py
+++ b/rift-engine/rift/ir/parser_ocaml.py
@@ -1,0 +1,141 @@
+from typing import List, Optional
+
+from tree_sitter import Node
+
+from rift.ir.parser_core import Counter, SymbolParser
+
+from .IR import (
+    FunctionKind,
+    ModuleKind,
+    Parameter,
+    Symbol,
+    Type,
+    ValueKind,
+)
+
+
+class OCamlParser(SymbolParser):
+    def process_body(self) -> Optional[Node]:
+        pass  # handled for each declaration in a let binding
+
+    def parse_symbols(self, counter: Counter) -> List[Symbol]:
+        if self.node.type == "value_definition":
+            parameters: List[Parameter] = []
+
+            def extract_type(node: Node, parent: Symbol) -> Type:
+                return Type.unknown(node.text.decode(), parent)
+
+            def parse_inner_parameter(inner: Node, parent: Symbol) -> Optional[Parameter]:
+                if inner.type in ["label_name", "value_pattern"]:
+                    name = inner.text.decode()
+                    return Parameter(name=name, parent=parent)
+                elif (
+                    inner.type == "typed_pattern"
+                    and inner.child_count == 5
+                    and inner.children[2].type == ":"
+                ):
+                    # "(", par, ":", typ, ")"
+                    id = inner.children[1]
+                    tp = inner.children[3]
+                    if id.type == "value_pattern":
+                        name = id.text.decode()
+                        type = extract_type(tp, parent)
+                        return Parameter(name=name, type=type, parent=parent)
+                elif inner.type == "unit":
+                    name = "()"
+                    type = Type.constructor(name="unit", parent=parent)
+                    return Parameter(name=name, type=type, parent=parent)
+
+            def parse_ocaml_parameter(parameter: Node, parent: Symbol) -> None:
+                if parameter.child_count == 1:
+                    inner_parameter = parse_inner_parameter(parameter.children[0], parent)
+                    if inner_parameter is not None:
+                        parameters.append(inner_parameter)
+                elif parameter.child_count == 2 and parameter.children[0].type in ["~", "?"]:
+                    inner_parameter = parse_inner_parameter(parameter.children[1], parent)
+                    if inner_parameter is not None:
+                        inner_parameter.name = parameter.children[0].type + inner_parameter.name
+                        parameters.append(inner_parameter)
+                elif (
+                    parameter.child_count == 4
+                    and parameter.children[0].type in ["~", "?"]
+                    and parameter.children[2].type == ":"
+                ):
+                    # "~", par, ":", name
+                    inner_parameter = parse_inner_parameter(parameter.children[1], parent)
+                    if inner_parameter is not None:
+                        inner_parameter.name = parameter.children[0].type + inner_parameter.name
+                        parameters.append(inner_parameter)
+                elif (
+                    parameter.child_count == 6
+                    and parameter.children[0].type in ["~", "?"]
+                    and parameter.children[3].type == ":"
+                ):
+                    # "~", "(", par, ":", typ, ")"
+                    inner_parameter = parse_inner_parameter(parameter.children[2], parent)
+                    if inner_parameter is not None:
+                        inner_parameter.name = parameter.children[0].type + inner_parameter.name
+                        type = extract_type(parameter.children[4], parent)
+                        inner_parameter.type = type
+                        parameters.append(inner_parameter)
+                elif (
+                    parameter.child_count == 6
+                    and parameter.children[0].type == "?"
+                    and parameter.children[3].type == "="
+                ):
+                    # "?", "(", par, "=", val, ")"
+                    inner_parameter = parse_inner_parameter(parameter.children[2], parent)
+                    if inner_parameter is not None:
+                        inner_parameter.name = parameter.children[0].type + inner_parameter.name
+                        type = extract_type(parameter.children[4], parent).type_of(parent)
+                        inner_parameter.type = type
+                        parameters.append(inner_parameter)
+
+            declarations: List[Symbol] = []
+            for child in self.node.children:
+                if child.type == "let_binding":
+                    pattern_node = child.child_by_field_name("pattern")
+                    if pattern_node is not None and pattern_node.type == "value_name":
+                        parents = [n for n in (child.prev_sibling, child) if n]
+                        # let rec: add node of type "let" if present before the first parent
+                        if (
+                            len(parents) > 0
+                            and parents[0].prev_sibling is not None
+                            and parents[0].prev_sibling.type == "let"
+                        ):
+                            parents = [parents[0].prev_sibling] + parents
+                        symbol = self.mk_dummy_symbol(id=pattern_node, parents=parents)
+                        for grandchild in child.children:
+                            if grandchild.type == "parameter":
+                                parse_ocaml_parameter(grandchild, parent=symbol)
+                        return_type, _ = self.process_ocaml_body(child, parent=symbol)
+                        if parameters != []:
+                            symbol_kind = FunctionKind(
+                                has_return=self.has_return,
+                                parameters=parameters,
+                                return_type=return_type,
+                                symbol=symbol,
+                            )
+                            self.update_dummy_symbol(symbol, symbol_kind)
+                        else:
+                            symbol_kind = ValueKind(type=return_type, symbol=symbol)
+                            self.update_dummy_symbol(symbol, symbol_kind)
+                        self.file.add_symbol(symbol)
+                        declarations.append(symbol)
+            return declarations
+
+        elif self.node.type == "module_definition":
+            for child in self.node.children:
+                if child.type == "module_binding":
+                    name = child.child_by_field_name("name")
+                    if name is not None:
+                        new_scope = self.scope + name.text.decode() + "."
+                        symbol = self.mk_dummy_symbol(id=name, parents=[self.node])
+                        _, body_node = self.process_ocaml_body(child, parent=symbol)
+                        if body_node is not None:
+                            self.recurse(body_node, new_scope, parent=symbol).parse_block()
+                        self.update_dummy_symbol(symbol, ModuleKind(symbol))
+                        self.file.add_symbol(symbol)
+                        return [symbol]
+
+        return super().parse_symbols(counter)

--- a/rift-engine/rift/ir/parser_rescript.py
+++ b/rift-engine/rift/ir/parser_rescript.py
@@ -1,0 +1,359 @@
+import logging
+from typing import List, Optional
+
+from tree_sitter import Node
+
+from rift.ir.parser_core import Counter, SymbolParser
+
+from .IR import (
+    Case,
+    Field,
+    FunctionKind,
+    IfKind,
+    Language,
+    ModuleKind,
+    Parameter,
+    SwitchKind,
+    Symbol,
+    Type,
+    TypeDefinitionKind,
+    ValueKind,
+)
+
+logger = logging.getLogger(__name__)
+
+
+def parse_type(language: Language, node: Node, parent: Symbol) -> Type:
+    if node.type == "type_identifier":
+        name = node.text.decode()
+        return Type.constructor(name=name, parent=parent)
+    elif node.type == "generic_type" and node.child_count == 2:
+        name = node.children[0].text.decode()
+        arguments_node = node.children[1]
+        if arguments_node.type == "type_arguments":
+            # remove first and last argument: < and >
+            arguments = arguments_node.children[1:-1]
+            arguments = [parse_type(language, n, parent) for n in arguments]
+            t = Type.constructor(name=name, arguments=arguments, parent=parent)
+            return t
+        else:
+            logger.warning(f"Unknown arguments_node type node: {arguments_node}")
+    else:
+        logger.warning(f"Unknown type node: {node}")
+
+    return Type.unknown(node.text.decode(), parent)
+
+
+class ReScriptParser(SymbolParser):
+    def process_body(self) -> Optional[Node]:
+        pass  # handled for each declaration in a let binding
+
+    def parse_symbols(self, counter: Counter) -> List[Symbol]:
+        if self.node.type == "let_declaration":
+            return_type = None
+
+            def parse_res_parameter(par: Node, parameters: List[Parameter], parent: Symbol) -> None:
+                if par.type in ["(", ")", ","]:
+                    pass
+                elif par.type == "parameter" and par.child_count >= 1:
+                    nodes = par.children
+                    type: Optional[Type] = None
+                    if (
+                        len(nodes) >= 2
+                        and nodes[1].type == "type_annotation"
+                        and len(nodes[1].children) >= 2
+                    ):
+                        type = parse_type(self.language, nodes[1].children[1], parent)
+                    default_value = None
+                    if nodes[0].type == "labeled_parameter":
+                        children = nodes[0].children
+                        default_value_node = nodes[0].child_by_field_name("default_value")
+                        if default_value_node is not None:
+                            next = default_value_node.next_sibling
+                            if next is not None:
+                                default_value = next.text.decode()
+                        for child in children:
+                            if child.type == "type_annotation" and len(child.children) >= 2:
+                                type = parse_type(self.language, child.children[1], parent)
+                        name = "~" + children[1].text.decode()
+                    else:
+                        name = nodes[0].text.decode()
+                    parameters.append(
+                        Parameter(default_value=default_value, name=name, type=type, parent=parent)
+                    )
+                else:
+                    logger.warning(f"Unexpected parameter type: {par.type}")
+
+            def parse_res_parameters(
+                exp: Node, parameters: List[Parameter], parent: Symbol
+            ) -> None:
+                nonlocal return_type
+                if exp.type == "function":
+                    parameters_node = exp.child_by_field_name("parameters")
+                    if parameters_node is not None:
+                        for par in parameters_node.children:
+                            parse_res_parameter(par, parameters, parent)
+                    parameter_node = exp.child_by_field_name("parameter")
+                    if parameter_node is not None:
+                        parameters.append(
+                            Parameter(
+                                default_value=None, name=parameter_node.text.decode(), parent=parent
+                            )
+                        )
+                    nodes = exp.children
+                    if len(nodes) >= 2:
+                        if nodes[1].type == "type_annotation" and nodes[1].child_count >= 2:
+                            return_type = parse_type(self.language, nodes[1].children[1], parent)
+                        if self.body_sub is not None:
+                            self.body_sub = (nodes[-2].start_byte, self.body_sub[1])
+
+            def parse_res_body(exp: Node, parent: Symbol, id_name: str) -> None:
+                if exp.type == "function":
+                    body_node = exp.child_by_field_name("body")
+                    if body_node is not None:
+                        counter = Counter()
+                        scope = self.scope + id_name + "."
+                        self.recurse(body_node, scope, parent=parent).parse_expression(counter)
+
+            def parse_res_let_binding(nodes: List[Node], parents: List[Node]) -> Optional[Symbol]:
+                id = None
+                exp = None
+                typ = None
+                if len(nodes) == 0:
+                    pass
+                elif (
+                    len(nodes) == 3
+                    and nodes[0].type == "value_identifier"
+                    and nodes[1].text == b"="
+                ):
+                    id = nodes[0]
+                    exp = nodes[2]
+                    self.body_sub = (nodes[1].start_byte, exp.end_byte)
+                elif (
+                    len(nodes) > 2
+                    and nodes[0].type == "parenthesized_pattern"
+                    and nodes[1].type == "="
+                ):
+                    pat = nodes[0].children[1:-1]  # remove ( and )
+                    return parse_res_let_binding(pat + nodes[1:], parents)
+                elif (
+                    len(nodes) == 4 and nodes[1].type == "type_annotation" and nodes[2].type == "="
+                ):
+                    id = nodes[0]
+                    typ = nodes[1]
+                    exp = nodes[3]
+                    self.body_sub = (nodes[2].start_byte, exp.end_byte)
+                elif len(nodes) == 4 and nodes[1].type == "as_aliasing" and nodes[2].type == "=":
+                    id = nodes[1].children[1]
+                    exp = nodes[3]
+                    self.body_sub = (nodes[2].start_byte, exp.end_byte)
+                elif nodes[0].type in ["tuple_pattern", "unit"]:
+                    pass
+                else:
+                    print(f"Unexpected let_binding nodes:{nodes}")
+                if id is not None and id.text != b"_":
+                    parameters: List[Parameter] = []
+                    symbol = self.mk_dummy_symbol(id=id, parents=parents)
+                    if exp is not None:
+                        parse_res_parameters(exp, parameters, parent=symbol)
+                    if parameters == []:
+                        type: Optional[Type] = None
+                        if typ is not None and typ.child_count >= 2:
+                            type = parse_type(self.language, typ.children[1], symbol)
+                        symbol_kind = ValueKind(type=type, symbol=symbol)
+                        self.update_dummy_symbol(symbol, symbol_kind)
+                    else:
+                        symbol_kind = FunctionKind(
+                            has_return=self.has_return,
+                            parameters=parameters,
+                            return_type=return_type,
+                            symbol=symbol,
+                        )
+                        self.update_dummy_symbol(symbol, symbol_kind)
+                    if exp is not None:
+                        parse_res_body(exp, symbol, id.text.decode())
+                    self.file.add_symbol(symbol)
+                    return symbol
+
+            declarations: List[Symbol] = []
+            for child in self.node.children:
+                if child.type == "let_binding":
+                    parents = [n for n in (child.prev_sibling, child) if n]
+                    # let rec: add node of type "let" if present before the first parent
+                    if (
+                        len(parents) > 0
+                        and parents[0].prev_sibling is not None
+                        and parents[0].prev_sibling.type == "let"
+                    ):
+                        parents = [parents[0].prev_sibling] + parents
+                    decl = parse_res_let_binding(nodes=child.children, parents=parents)
+                    if decl is not None:
+                        declarations.append(decl)
+            return declarations
+
+        elif self.node.type == "module_declaration":
+
+            def parse_module_binding(nodes: List[Node]) -> List[Symbol]:
+                id = None
+                body = None
+                if (
+                    len(nodes) == 3
+                    and nodes[0].type == "module_identifier"
+                    and nodes[1].type == "="
+                ):
+                    id = nodes[0]
+                    body = nodes[2]
+                    self.body_sub = (nodes[0].end_byte, nodes[2].end_byte)
+                elif (
+                    len(nodes) == 5
+                    and nodes[0].type == "module_identifier"
+                    and nodes[1].type == ":"
+                    and nodes[3].type == "="
+                ):
+                    id = nodes[0]
+                    body = nodes[4]
+                    self.body_sub = (nodes[0].end_byte, nodes[4].end_byte)
+                else:
+                    print(f"Unexpected module_binding nodes:{len(nodes)}")
+                if id is not None and body is not None:
+                    new_scope = self.scope + id.text.decode() + "."
+                    symbol = self.mk_dummy_symbol(id=id, parents=[self.node])
+                    self.recurse(body, new_scope, parent=symbol).parse_block()
+                    self.update_dummy_symbol(symbol, ModuleKind(symbol))
+                    self.file.add_symbol(symbol)
+                    return [symbol]
+                else:
+                    return []
+
+            if len(self.node.children) == 2:
+                m1 = self.node.children[1]
+                if m1.type == "module_binding":
+                    nodes = m1.children
+                    return parse_module_binding(nodes)
+                else:
+                    logger.warning(f"Unexpected node type in module_declaration: {m1.type}")
+
+        elif self.node.type == "type_declaration":
+
+            def parse_type_body(body: Node, parent: Symbol) -> Optional[Type]:
+                if body.type == "record_type":
+                    fields: List[Field] = []
+                    for f in body.children:
+                        if f.type == "record_type_field":
+                            children = f.children
+                            field = None
+                            if (
+                                len(children) == 3
+                                and children[0].type == "property_identifier"
+                                and children[1].type == "?"
+                                and children[2].type == "type_annotation"
+                            ):
+                                fname = children[0].text.decode()
+                                optional = True
+                                type = parse_type(self.language, children[2].children[1], parent)
+                                field = Field(fname, optional, parent, type)
+                            elif (
+                                len(children) == 2
+                                and children[0].type == "property_identifier"
+                                and children[1].type == "type_annotation"
+                            ):
+                                fname = children[0].text.decode()
+                                optional = False
+                                type = parse_type(self.language, children[1].children[1], parent)
+                                field = Field(fname, optional, parent, type)
+                            else:
+                                logger.warning(
+                                    f"Unexpected node structure in record_type_field: {f.text.decode()}"
+                                )
+                            if field is not None:
+                                fields.append(field)
+                    return Type.record(fields, parent=parent)
+                else:
+                    logger.warning(f"Unexpected node type in type_declaration: {body.type}")
+                    return None
+
+            if len(self.node.children) == 2:
+                t1 = self.node.children[1]
+                node_name = t1.child_by_field_name("name")
+                node_body = t1.child_by_field_name("body")
+                if t1.type == "type_binding" and node_name is not None:
+                    symbol = self.mk_dummy_symbol(id=node_name, parents=[self.node])
+                    type = None
+                    if node_body is not None:
+                        type = parse_type_body(node_body, symbol)
+                    elif len(t1.children) == 3 and t1.children[1].type == "=":
+                        type = parse_type(self.language, t1.children[2], symbol)
+                    else:
+                        logger.warning(
+                            f"Unexpected node structure in type_binding: {t1.text.decode()}"
+                        )
+                    if type is not None:
+                        symbol_kind = TypeDefinitionKind(symbol, type)
+                        self.update_dummy_symbol(symbol, symbol_kind)
+                        self.file.add_symbol(symbol)
+                        return [symbol]
+                else:
+                    logger.warning(f"Unexpected node type in type_declaration: {t1.type}")
+                return []
+
+        return super().parse_symbols(counter)
+
+    def parse_metasymbol(self, counter: Counter) -> Optional[Symbol]:
+        node = self.node
+        if node.type == "if_expression" and node.child_count >= 3:
+            guard_node = node.children[1]
+            body_node = node.children[2]
+            else_node = None
+            if node.child_count >= 4:
+                else_node = node.children[3]
+            if_symbol = self.mk_dummy_metasymbol(counter, "if")
+            scope = self.scope
+            if_guard = self.recurse(guard_node, scope, parent=if_symbol).parse_guard(counter)
+            if_body = self.recurse(body_node, scope, parent=if_symbol).parse_body(counter)
+            if_case = Case(guard=if_guard, body=if_body)
+            else_body = None
+            if else_node is not None and else_node.child_count >= 2:
+                else_body = self.recurse(else_node.children[1], scope, parent=if_symbol).parse_body(
+                    counter
+                )
+            if_kind = IfKind(if_symbol, if_case=if_case, elif_cases=[], else_body=else_body)
+            self.update_dummy_symbol(symbol=if_symbol, symbol_kind=if_kind)
+            self.file.add_symbol(if_symbol)
+            return if_symbol
+
+        elif node.type == "switch_expression":
+            if node.child_count >= 3:
+                switch_symbol = self.mk_dummy_metasymbol(counter, "switch")
+                scope = self.scope
+                expression_node = node.children[1]
+                expression = self.recurse(expression_node, scope, parent=switch_symbol).parse_guard(
+                    counter
+                )
+                cases: List[Case] = []
+                for case_node in node.children[2:]:
+                    pattern_node = case_node.child_by_field_name("pattern")
+                    body_node = case_node.child_by_field_name("body")
+                    if pattern_node is not None and body_node is not None:
+                        pattern = self.recurse(
+                            pattern_node, scope, parent=switch_symbol
+                        ).parse_guard(counter)
+                        body = self.recurse(body_node, scope, parent=switch_symbol).parse_body(
+                            counter
+                        )
+                        cases.append(Case(guard=pattern, body=body))
+                switch_kind = SwitchKind(
+                    switch_symbol, expression=expression, cases=cases, default=None
+                )
+                self.update_dummy_symbol(symbol=switch_symbol, symbol_kind=switch_kind)
+                self.file.add_symbol(switch_symbol)
+                return switch_symbol
+
+        return super().parse_metasymbol(counter)
+
+    def walk_expression(self, counter: Counter) -> None:
+        if self.node.type in ["if_expression", "switch_expression"]:
+            self.parse_symbols(counter)
+        elif self.node.type == "block":
+            self.parse_block()
+
+        super().walk_expression(counter)

--- a/rift-engine/rift/ir/parser_rescript.py
+++ b/rift-engine/rift/ir/parser_rescript.py
@@ -45,9 +45,6 @@ def parse_type(language: Language, node: Node, parent: Symbol) -> Type:
 
 
 class ReScriptParser(SymbolParser):
-    def process_body(self) -> Optional[Node]:
-        pass  # handled for each declaration in a let binding
-
     def parse_symbols(self, counter: Counter) -> List[Symbol]:
         if self.node.type == "let_declaration":
             return_type = None


### PR DESCRIPTION
The remaining languages are quite uniform and share most code.
Perhaps some more separation can be done later.