### PR TITLE
IR: expressions can be literals of symbols

### DIFF
--- a/rift-engine/rift/agents/linter_agent.py
+++ b/rift-engine/rift/agents/linter_agent.py
@@ -56,7 +56,8 @@ class GenerateCodePrompt:
             
             You MUST format your response as a *code block*:
                 ```python
-                for x in __set__: ...
+                for x in __set__:
+                    ...
                 ```
             
             The function must be written in the following subset of Python:
@@ -64,6 +65,7 @@ class GenerateCodePrompt:
             - sets `__set__` can be one of ["$Call", "$Class", "$File", "$Function", "$Method", "$Module", "$Namespace", "$TypeDefinition"]
             - __body__ performs a check on using the following functions:
                 - `$check(x, __expression__)` where `x` is an element of a __set__
+                - Note: `$check` MUST be called with 2 arguments.
             - __expression__ can be one of the following categories:
                 - `x.id`
                 - boolean, and equality operations
@@ -74,7 +76,7 @@ class GenerateCodePrompt:
                 - `t.fields` when `d` is a record type definition
                 - `f.id` and `f.type` and `f.optional` when `f` is a field
                 - 'c.function_name` and `c.arguments` when `c` is in "$Call"
-                - `e.kind` is in ["Array", "Tuple", "Switch", ...]
+                - `e.kind` can be "Array", "Tuple", "Switch", ... if `e` is an expression
             - A call is at toplevel if the parent is a function
 
             Example:
@@ -84,7 +86,8 @@ class GenerateCodePrompt:
             ```
             You will generate the following *code block*:
             ```python
-            for x in $Function: $check(x, x.id[0] == 'f')
+            for x in $Function:
+                $check(x, x.id[0] == 'f')
             ```
 
             Example:
@@ -94,7 +97,8 @@ class GenerateCodePrompt:
             ```
             You will generate the following *code block*:
             ```python
-            for x in $TypeDefinition: if x.type.kind == 'record': $check(x, 'name' in x.type.fields)
+            for x in $TypeDefinition:
+                /if x.type.kind == 'record': $check(x, 'name' in x.type.fields)
             ```
             """
         ).lstrip()

--- a/rift-engine/rift/ir/IR.py
+++ b/rift-engine/rift/ir/IR.py
@@ -62,7 +62,47 @@ class CodeEdit:
         return Code(code.bytes[:start] + self.new_bytes + code.bytes[end:])
 
 
-Expression = str
+@dataclass
+class Expression(ABC):
+    """Abstract class for expressions."""
+
+    @abstractproperty
+    def kind(self) -> str:
+        raise NotImplementedError
+
+
+@dataclass
+class LiteralExpression(Expression):
+    """Represents a literal expression: the string is obtained by substituting symbol names in the code"""
+
+    value: str
+
+    @property
+    def kind(self) -> str:
+        return "Literal"
+
+    def __str__(self) -> str:
+        return self.value
+
+    def __repr__(self) -> str:
+        return self.__str__()
+
+
+@dataclass
+class SymbolExpression(Expression):
+    """Represents an expression which is a recognized symbol"""
+
+    symbol: "Symbol"
+
+    @property
+    def kind(self) -> str:
+        return self.symbol.kind
+
+    def __str__(self) -> str:
+        return self.symbol.id
+
+    def __repr__(self) -> str:
+        return self.__str__()
 
 
 @dataclass
@@ -294,7 +334,8 @@ class ArrayKind(MetaSymbolKind):
         lines.append(f"   elements: {self.elements}")
 
     def __str__(self) -> str:
-        return f"[{', '.join(self.elements)}]"
+        elements = [str(element) for element in self.elements]
+        return f"[{', '.join(elements)}]"
 
     def __repr__(self) -> str:
         return self.__str__()
@@ -343,7 +384,8 @@ class CallKind(MetaSymbolKind):
             lines.append(f"   arguments: {self.arguments}")
 
     def __str__(self) -> str:
-        return f"{self.function_name}({', '.join(self.arguments)})"
+        arguments = [str(argument) for argument in self.arguments]
+        return f"{self.function_name}({', '.join(arguments)})"
 
     def __repr__(self) -> str:
         return self.__str__()
@@ -385,17 +427,17 @@ class ExpressionKind(MetaSymbolKind):
         code (str): The code string that represents the expression.
     """
 
-    code: str
+    expression: Expression
 
     @property
     def kind(self) -> SymbolKindName:
         return "Expression"
 
     def dump(self, lines: List[str]) -> None:
-        lines.append(f"   code: {self.code}")
+        lines.append(f"   expression: {self.expression}")
 
     def __str__(self) -> str:
-        return self.code
+        return str(self.expression)
 
     def __repr__(self) -> str:
         return self.__str__()
@@ -478,7 +520,7 @@ class GuardKind(MetaSymbolKind):
         lines.append(f"   condition: {self.condition}")
 
     def __str__(self) -> str:
-        return self.condition
+        return str(self.condition)
 
     def __repr__(self) -> str:
         return self.__str__()
@@ -623,7 +665,8 @@ class TupleKind(MetaSymbolKind):
         lines.append(f"   elements: {self.elements}")
 
     def __str__(self) -> str:
-        return f"({', '.join(self.elements)})"
+        elements = [str(element) for element in self.elements]
+        return f"({', '.join(elements)})"
 
     def __repr__(self) -> str:
         return self.__str__()

--- a/rift-engine/rift/ir/metalanguage.py
+++ b/rift-engine/rift/ir/metalanguage.py
@@ -137,7 +137,7 @@ def test_meta_language():
         """
         for x in $Call:
             if x.function_name == 'useEffect':
-                $check(x, x.arguments[1].kind in ['Array', 'Tuple'])
+                $check(x, x.arguments[1].kind in ['Tuple', 'Array'])
         """
     ).lstrip()
 

--- a/rift-engine/rift/ir/parser_core.py
+++ b/rift-engine/rift/ir/parser_core.py
@@ -21,12 +21,14 @@ from .IR import (
     Import,
     InterfaceKind,
     Language,
+    LiteralExpression,
     ModuleKind,
     NamespaceKind,
     Parameter,
     Scope,
     Substring,
     Symbol,
+    SymbolExpression,
     SymbolKind,
     Type,
     TypeDefinitionKind,
@@ -723,13 +725,18 @@ class SymbolParser:
         """
         Parse an expression to generate its corresponding code with symbols replaced by their names.
         """
+        
+        self_rec = self.recurse(self.node, self.scope, parent=self.parent)
+        symbol = self_rec.parse_metasymbol(counter)
+        if symbol is not None:
+            return SymbolExpression(symbol)
 
-        self.recurse(self.node, self.scope, parent=self.parent).walk_expression(counter)
+        self_rec.walk_expression(counter)
 
         code = self.node.text.decode()
 
         if self.parent is None:
-            return code
+            return LiteralExpression(code)
 
         # Get a list of symbols from the parent's body
         symbols = self.parent.body
@@ -747,7 +754,7 @@ class SymbolParser:
             if start >= 0 and end <= len(code):
                 code = code[:start] + symbol.id + code[end:]
 
-        return code
+        return LiteralExpression(code)
 
     @classmethod
     def expression_requires_node(cls, node: Node) -> bool:

--- a/rift-engine/rift/ir/parser_core.py
+++ b/rift-engine/rift/ir/parser_core.py
@@ -725,7 +725,7 @@ class SymbolParser:
         """
         Parse an expression to generate its corresponding code with symbols replaced by their names.
         """
-        
+
         self_rec = self.recurse(self.node, self.scope, parent=self.parent)
         symbol = self_rec.parse_metasymbol(counter)
         if symbol is not None:

--- a/rift-engine/rift/ir/symbol_table.txt
+++ b/rift-engine/rift/ir/symbol_table.txt
@@ -183,7 +183,7 @@ Call: call$0
    scope: if$0.body$0.
    parent: if$0.body$0
    function_name: console.log
-   arguments: ['"true"']
+   arguments: ["true"]
 Call: call$1
    language: typescript
    range: ((17, 4), (17, 19))
@@ -191,7 +191,7 @@ Call: call$1
    scope: if$0.body$0.
    parent: if$0.body$0
    function_name: congole.log
-   arguments: ['42']
+   arguments: [42]
 Body: body$0
    language: typescript
    range: ((15, 10), (18, 1))
@@ -207,7 +207,7 @@ Call: call$0
    scope: if$0.body$1.
    parent: if$0.body$1
    function_name: console.log
-   arguments: ['"false"']
+   arguments: ["false"]
 Body: body$1
    language: typescript
    range: ((18, 7), (20, 1))
@@ -236,7 +236,7 @@ Expression: expression$0
    range: ((0, 0), (0, 22))
    substring: (0, 22)
    parent: test.tsx
-   code: d = <div> "abc" </div>
+   expression: d = <div> "abc" </div>
 Function: tsx
    language: tsx
    range: ((1, 0), (1, 27))
@@ -257,7 +257,7 @@ Expression: expression$0
    substring: (18, 69)
    scope: A.
    parent: A
-   code: """
+   expression: """
     This is a docstring
     for class A
     """
@@ -267,7 +267,7 @@ Expression: expression$0
    substring: (97, 122)
    scope: A.py.
    parent: A.py
-   code: """This is a docstring"""
+   expression: """This is a docstring"""
 Function: py
    language: python
    range: ((6, 4), (8, 16))
@@ -357,7 +357,7 @@ Expression: expression$0
    substring: (647, 664)
    scope: some_conditionals.
    parent: some_conditionals
-   code: """explanation"""
+   expression: """explanation"""
 Guard: guard$0
    language: python
    range: ((33, 7), (33, 18))
@@ -475,7 +475,7 @@ Call: call$0
    scope: with_nested_conditionals.if$0.body$0.if$0.body$0.expression$0.
    parent: with_nested_conditionals.if$0.body$0.if$0.body$0.expression$0
    function_name: foo
-   arguments: ['1']
+   arguments: [1]
 Call: call$1
    language: python
    range: ((50, 25), (50, 31))
@@ -483,7 +483,7 @@ Call: call$1
    scope: with_nested_conditionals.if$0.body$0.if$0.body$0.expression$0.call.
    parent: with_nested_conditionals.if$0.body$0.if$0.body$0.expression$0
    function_name: bar
-   arguments: ['2']
+   arguments: [2]
 Expression: expression$0
    language: python
    range: ((50, 12), (50, 31))
@@ -491,7 +491,7 @@ Expression: expression$0
    scope: with_nested_conditionals.if$0.body$0.if$0.body$0.
    body: ['call$0', 'call$1']
    parent: with_nested_conditionals.if$0.body$0.if$0.body$0
-   code: x = call$0 + call$1
+   expression: x = call$0 + call$1
 Body: body$0
    language: python
    range: ((50, 12), (50, 31))
@@ -522,7 +522,7 @@ Call: call$0
    scope: with_nested_conditionals.if$0.body$0.if$1.body$1.
    parent: with_nested_conditionals.if$0.body$0.if$1.body$1
    function_name: print
-   arguments: ['"hello"']
+   arguments: ["hello"]
 Call: call$1
    language: python
    range: ((53, 12), (53, 26))
@@ -530,7 +530,7 @@ Call: call$1
    scope: with_nested_conditionals.if$0.body$0.if$1.body$1.
    parent: with_nested_conditionals.if$0.body$0.if$1.body$1
    function_name: print
-   arguments: ['"world"']
+   arguments: ["world"]
 Body: body$1
    language: python
    range: ((52, 12), (53, 26))
@@ -579,7 +579,7 @@ Call: call$0
    scope: for$0.
    parent: for$0
    function_name: range
-   arguments: ['10']
+   arguments: [10]
 Call: call$0
    language: python
    range: ((56, 4), (56, 15))
@@ -587,7 +587,7 @@ Call: call$0
    scope: for$0.body$0.
    parent: for$0.body$0
    function_name: print
-   arguments: ['i+1']
+   arguments: [i+1]
 Call: call$1
    language: python
    range: ((57, 14), (57, 31))
@@ -595,7 +595,7 @@ Call: call$1
    scope: for$0.body$0.expression$0.
    parent: for$0.body$0.expression$0
    function_name: get_some_value
-   arguments: ['i']
+   arguments: [i]
 Expression: expression$0
    language: python
    range: ((57, 4), (57, 32))
@@ -603,7 +603,7 @@ Expression: expression$0
    scope: for$0.body$0.
    body: ['call$1']
    parent: for$0.body$0
-   code: x = await(call$1)
+   expression: x = await(call$1)
 Body: body$0
    language: python
    range: ((56, 4), (57, 32))

--- a/rift-engine/rift/ir/tests/record.res
+++ b/rift-engine/rift/ir/tests/record.res
@@ -10,6 +10,14 @@ let useAtToplevel = x => {
   useState([1, 2, [3, 4]], ("a", "b"))
 }
 
-let testUseEffect = f => {
+let testUseEffect1 = f => {
   useEffect(f, [1, 2, 3])
+}
+
+let testUseEffect2 = f => {
+  useEffect(f, (1,2))
+}
+
+let testUseEffect2 = f => {
+  useEffect(f, 10)
 }


### PR DESCRIPTION
This allows to capture the symbol inside an expression when available. If the expression corresponds to a recognised metasymbol, then it will be that symbol. Otherwise it will be the string corresponding to the original code, but where the symbol names will be replaces for the corresponding parts of code.